### PR TITLE
feat: Cloudinary no longer required. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ backend/detailed-requests.log
 backend/http-requests.log
 backend/src/NOTES.txt
 backend/errors.log
-
+frontend/.env

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,7 @@
         "reflect-metadata": "^0.2.2",
         "socket.io": "^4.8.1",
         "tsyringe": "^4.8.0",
+        "uuid": "^11.1.0",
         "validator": "^13.12.0",
         "winston": "^3.17.0"
       },
@@ -6573,6 +6574,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "reflect-metadata": "^0.2.2",
     "socket.io": "^4.8.1",
     "tsyringe": "^4.8.0",
+    "uuid": "^11.1.0",
     "validator": "^13.12.0",
     "winston": "^3.17.0"
   },

--- a/backend/src/di/container.ts
+++ b/backend/src/di/container.ts
@@ -40,9 +40,24 @@ import { FeedController } from '../controllers/feed.controller';
 import { FeedRoutes } from '../routes/feed.routes';
 import { UserPreferenceRepository } from '../repositories/userPreference.repository';
 import { RedisService } from '../services/redis.service';
+import { LocalStorageService } from '../services/localStorage.service';
+import { IImageStorageService } from '../types/index';
 
 
 export function setupContainer(): void {
+
+  // Check if Cloudinary is configured
+  const isCloudinaryConfigured =
+  process.env.CLOUDINARY_CLOUD_NAME &&
+  process.env.CLOUDINARY_API_KEY &&
+  process.env.CLOUDINARY_API_SECRET;
+
+
+
+  const ImageStorageService = isCloudinaryConfigured ? CloudinaryService : LocalStorageService;
+  if(!isCloudinaryConfigured){
+    console.log('No Cloudinary credentials detected. \r\nDefaulting to local storage.')
+  }
 
   // Register Models
   container.register('UserModel', { useValue: User });
@@ -70,7 +85,6 @@ export function setupContainer(): void {
 
   // Register Services as singletons
   container.registerSingleton('SearchService', SearchService);
-  container.registerSingleton('CloudinaryService', CloudinaryService);
   container.registerSingleton('UserService', UserService);
   container.registerSingleton('ImageService', ImageService);
   container.registerSingleton('FollowService', FollowService);
@@ -78,7 +92,10 @@ export function setupContainer(): void {
   container.registerSingleton('UserDTOService', UserDTOService);
   container.registerSingleton('FeedService', FeedService);
   container.registerSingleton('RedisService', RedisService);
+  container.registerSingleton<IImageStorageService>('ImageStorageService', ImageStorageService); 
 
+  
+  
   // Register Controllers as singletons
   container.registerSingleton('SearchController', SearchController);
   container.registerSingleton('UserController', UserController);

--- a/backend/src/models/image.model.ts
+++ b/backend/src/models/image.model.ts
@@ -134,7 +134,7 @@ imageSchema.pre('findOneAndDelete', async function (next) {
     }
 
     if (doc.user._id) {
-      console.log(`deleting image ${doc._id} from user ${doc.user.username} with user id ${doc.user._id}`)
+      console.log(`deleting image ${doc._id} from  user  id ${doc.user._id}`)
       await User.findByIdAndUpdate(
         doc.user._id,
         { $pull: { images: doc.url } },

--- a/backend/src/repositories/base.repository.ts
+++ b/backend/src/repositories/base.repository.ts
@@ -38,6 +38,7 @@ export abstract class BaseRepository<T extends mongoose.Document> implements IRe
       if (session) query.session(session); 
       return await query.exec();
     } catch (error) {
+
       throw createError('UoWError', error.message);
     }
   }
@@ -50,9 +51,10 @@ export abstract class BaseRepository<T extends mongoose.Document> implements IRe
    */
   async delete(id: string, session?: ClientSession): Promise<boolean> {
     try {
-      const query = this.model.findByIdAndDelete(id);
+      const query = this.model.findOneAndDelete({_id: id});
       if (session) query.session(session); 
       const result = await query.exec();
+      console.log(`result from execution of delete in imageRepository: ${result}`)
       return result !== null;
     } catch (error) {
       throw createError('UoWError', error.message)

--- a/backend/src/server/server.ts
+++ b/backend/src/server/server.ts
@@ -11,6 +11,7 @@ import { AdminUserRoutes } from '../routes/admin.routes';
 import { detailedRequestLogging, logBehaviour } from '../middleware/logMiddleware';
 import { NotificationRoutes } from '../routes/notification.routes';
 import { FeedRoutes } from '../routes/feed.routes';
+import path from 'path';
 @injectable()
 export class Server {
   private app: Application;
@@ -51,7 +52,8 @@ export class Server {
     this.app.use('/api/search', this.searchRoutes.getRouter());
     this.app.use('/api/admin', this.adminUserRoutes.getRouter());
     this.app.use('/api/notifications/', this.notificationRoutes.getRouter());
-    this.app.use('/api/feed', this.feedRoutes.getRouter())
+    this.app.use('/api/feed', this.feedRoutes.getRouter());
+    this.app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
     // this.app.use('/api/follows', this.followRouter.getRouters());
    
   }

--- a/backend/src/services/feed.service.ts
+++ b/backend/src/services/feed.service.ts
@@ -13,7 +13,7 @@ export class FeedService {
     @inject('UserRepository') private userRepository: UserRepository,
     @inject('UserPreferenceRepository') private userPreferenceRepository: UserPreferenceRepository,
     @inject('UserActionRepository') private userActionRepository: UserActionRepository,
-    @inject('RedisService') private redisService: RedisService // Add this
+    @inject('RedisService') private redisService: RedisService
   ) {}
 
   public async getPersonalizedFeed(userId: string, page: number, limit: number): Promise<any> {
@@ -53,7 +53,7 @@ export class FeedService {
         skip
       );
 
-      await this.redisService.set(cacheKey, feed, 1800); // Cache feed for 20 minutes
+      await this.redisService.set(cacheKey, feed, 120); // Cache feed for 2 minutes
       return feed;
 
     } catch (error) {

--- a/backend/src/services/localStorage.service.ts
+++ b/backend/src/services/localStorage.service.ts
@@ -1,0 +1,114 @@
+import { v4 as uuidv4 } from 'uuid';
+import * as fs from 'fs';
+import * as path from 'path';
+import { IImageStorageService } from '../types';
+import { injectable } from 'tsyringe';
+import { createError } from '../utils/errors';
+
+@injectable()
+export class LocalStorageService implements IImageStorageService {
+  private uploadsDir: string;
+
+  constructor() {
+    this.uploadsDir = path.join(process.cwd(), 'uploads'); //process.cwd() gets to the root of the project
+
+    //Create the uploadsDir if it's missing
+    if (!fs.existsSync(this.uploadsDir)) {
+      fs.mkdirSync(this.uploadsDir, { recursive: true });
+    }
+  }
+
+  async uploadImage(file: Buffer, username: string): Promise<{ url: string; publicId: string }> {
+    try {
+      const filename = `${uuidv4()}.png`; // uuidv4() generates a unique filename
+      const userDir = path.join(this.uploadsDir, username); // Create a user-specific directory
+      const filepath = path.join(userDir, filename); 
+
+      if (!fs.existsSync(userDir)) {
+        fs.mkdirSync(userDir, { recursive: true });
+      }
+
+      await fs.promises.writeFile(filepath, file);
+      const url = `/uploads/${username}/${filename}`;
+
+      return { url, publicId: filename };
+    } catch (error) {
+      console.error(error);
+      throw createError(error.name, error.message);
+    }
+  }
+
+  async deleteImage(publicId: string): Promise<void>{
+    try {
+      const filePath = path.join(this.uploadsDir, publicId);
+
+      if(fs.existsSync(filePath)){
+        await fs.promises.unlink(filePath);
+      }
+    } catch (error) {
+      console.error(error)
+      throw createError(error.name, error.message)
+    }
+  }
+
+  async deleteAssetByUrl(username: string, url: string): Promise<{ result: string }> {
+    try {
+      console.log('URL of image about to delete:', url);
+
+      const publicId = this.extractPublicId(url);
+      if (!publicId) {
+        throw createError('InvalidURL', 'Could not extract publicId from URL');
+      }
+
+      const assetPath = path.join(this.uploadsDir, username, publicId);
+      await fs.promises.unlink(assetPath);
+
+      return { result: 'ok' };
+    } catch (error) {
+      console.error('Error deleting asset:', error);
+      throw createError('StorageError', error.message);
+    }
+  }
+  
+
+  async deleteMany(username: string): Promise<{ result: 'ok' | 'error'; message?: string }> {
+    try {
+      const userDir = path.join(this.uploadsDir, username);
+
+      if (!fs.existsSync(userDir)) {
+        return { result: 'ok', message: 'User folder does not exist, nothing to delete.' };
+      }
+
+      const files = await fs.promises.readdir(userDir);
+
+      if (files.length === 0) {
+        return { result: 'ok', message: 'User folder is already empty.' };
+      }
+
+      // Delete all files inside the user's folder
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(userDir, file);
+          await fs.promises.unlink(filePath);
+        })
+      );
+
+      // Remove the folder after deleting its contents
+      await fs.promises.rmdir(userDir);
+
+      return { result: 'ok', message: `Successfully deleted all images for user: ${username}` };
+    } catch (error) {
+      console.error('Error deleting multiple assets:', error);
+      return {
+        result: 'error',
+        message: error.message || 'Error deleting local storage resources',
+      };
+    }
+  }
+
+  private extractPublicId(url: string): string | null {
+    const regex = /\/uploads\/(?:[^\/]+)\/([^\/]+)$/;
+    const matches = url.match(regex);
+    return matches ? matches[1] : null;
+  }
+}

--- a/backend/src/services/redis.service.ts
+++ b/backend/src/services/redis.service.ts
@@ -8,7 +8,7 @@ export class RedisService {
   constructor() {
     this.client = createClient({
       url: process.env.REDIS_URL || 
-           `redis://${process.env.NODE_ENV === "development" ? 'localhost:6379' : 'redis:6379'}`,
+        `redis://${process.env.NODE_ENV === "development" ? 'localhost:6379' : 'redis:6379'}`,
     });
     
 

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,7 +1,6 @@
-import { Model, ClientSession } from 'mongoose';
+import { Model } from 'mongoose';
 import { UserRepository } from '../repositories/user.repository';
-import { IImage, IUser, PaginationOptions, PaginationResult } from '../types';
-import  {CloudinaryService}  from './cloudinary.service';
+import { IImage, IImageStorageService, IUser, PaginationOptions, PaginationResult } from '../types';
 import { ImageRepository } from '../repositories/image.repository';
 import { createError } from '../utils/errors';
 import jwt from 'jsonwebtoken';
@@ -25,7 +24,7 @@ export class UserService {
   constructor(
     @inject('UserRepository') private readonly userRepository: UserRepository,
     @inject('ImageRepository') private readonly imageRepository: ImageRepository,
-    @inject('CloudinaryService') private readonly cloudinaryService: CloudinaryService,
+    @inject('ImageStorageService') private readonly imageStorageService: IImageStorageService, 
     @inject('UserModel') private readonly userModel: Model<IUser>,
     @inject('UnitOfWork') private readonly unitOfWork: UnitOfWork,
     @inject('LikeRepository') private readonly likeRepository: LikeRepository,
@@ -156,12 +155,12 @@ export class UserService {
       }
 
       const oldAvatarUrl = user.avatar;
-      const cloudImage = await this.cloudinaryService.uploadImage(file, user.username);
+      const cloudImage = await this.imageStorageService.uploadImage(file, user.username);
       
       await this.userRepository.updateAvatar(userId, cloudImage.url, session);
       
       if (oldAvatarUrl) {
-        await this.cloudinaryService.deleteAssetByUrl(userId, oldAvatarUrl);
+        await this.imageStorageService.deleteAssetByUrl(userId, oldAvatarUrl);
       }
     })
     } catch (error) {
@@ -183,12 +182,12 @@ export class UserService {
         }
 
         const oldCoverUrl = user.cover;
-        const cloudImage = await this.cloudinaryService.uploadImage(file, user.username);
+        const cloudImage = await this.imageStorageService.uploadImage(file, user.username);
         
         await this.userRepository.updateCover(userId, cloudImage.url, session);
 
         if (oldCoverUrl) {
-          await this.cloudinaryService.deleteAssetByUrl(userId, oldCoverUrl);
+          await this.imageStorageService.deleteAssetByUrl(userId, oldCoverUrl);
         }
     })
     } catch (error) {
@@ -210,7 +209,7 @@ export class UserService {
       }
 
       if(user.images.length > 0 ){
-        const cloudResult = await this.cloudinaryService.deleteMany(user.username);
+        const cloudResult = await this.imageStorageService.deleteMany(user.username);
         if (cloudResult.result !== 'ok' ) {
           throw createError('CloudinaryError', cloudResult.message || 'Error deleting cloudinary data');
         }

--- a/backend/src/types/customCloudinary/cloudinary.types.ts
+++ b/backend/src/types/customCloudinary/cloudinary.types.ts
@@ -3,7 +3,7 @@ export interface CloudinaryResponse {
   message?: string;
 }
 
-export interface CloudinaryResult {
+export interface DeletionResult {
   result: 'ok' | 'error';
   message?: string;
 }

--- a/backend/src/types/customImageStorage/imageStorage.types.ts
+++ b/backend/src/types/customImageStorage/imageStorage.types.ts
@@ -1,0 +1,11 @@
+
+
+export interface IImageStorageService {
+  uploadImage(file: Buffer, username: string): Promise<{url: string, publicId: string}>;
+  deleteImage(publicId: string): Promise<void>;
+  deleteAssetByUrl(username: string, url: string): Promise<{result: string}>;
+  deleteMany(username: string): Promise<{
+    result: 'ok' | 'error';
+    message?: string;
+  }>
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -10,3 +10,4 @@ export * from './customUserAction/userAction.types';
 export * from './customUsers/user.types';
 export * from './customUsers/dto.types';
 export * from './customUserPreference/userPreference.types'
+export * from './customImageStorage/imageStorage.types'

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -48,12 +48,6 @@ class InternalServerError extends AppError {
   }
 }
 
-class CloudError extends AppError {
-  constructor(message: string){
-    super('CloudError', message, 500)
-  }
-}
-
 class UnknownError extends AppError {
   constructor(message: string) {
     super('UnknownError', message, 500);
@@ -79,6 +73,12 @@ class UoWError extends AppError{
   }
 }
 
+class StorageError extends AppError{
+  constructor(message: string){
+    super('StorageError', message, 500)
+  }
+}
+
 const errorMap: { [key: string]: new (message: string) => AppError } = {
   ValidationError,
   UnauthorizedError,
@@ -86,11 +86,12 @@ const errorMap: { [key: string]: new (message: string) => AppError } = {
   PathError,
   DuplicateError,
   InternalServerError,
-  CloudError,
+  StorageError,
   UnknownError,
   TransactionError,
   UoWError,
   DatabaseError
+  
 };
 
 export function createError(type: string, message: string, context?: any): AppError {

--- a/frontend/src/api/axiosClient.ts
+++ b/frontend/src/api/axiosClient.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-const baseURL = import.meta.env.VITE_API_URL || '/api';
+const baseURL = '/api';
 const axiosClient = axios.create({
   baseURL, 
   withCredentials: true,

--- a/frontend/src/components/Gallery.tsx
+++ b/frontend/src/components/Gallery.tsx
@@ -9,6 +9,8 @@ import ImageCard from './ImageCard';
 import { useGallery } from '../context/GalleryContext';
 import { useAuth } from '../hooks/context/useAuth';
 
+const BASE_URL = import.meta.env.VITE_API_URL;
+
 const Gallery: React.FC<GalleryProps> = ({ images, fetchNextPage, hasNextPage, isFetchingNext, isLoadingFiltered, isLoadingAll }) => {
   const navigate = useNavigate()
   const { user, isLoggedIn } = useAuth();
@@ -95,6 +97,9 @@ const Gallery: React.FC<GalleryProps> = ({ images, fetchNextPage, hasNextPage, i
     });
   };
 
+  const fullImageUrl = selectedImage?.url.startsWith('http') ? selectedImage.url : `${BASE_URL}${selectedImage?.url}`;
+
+
   return (
     <Box sx={{
       display: 'flex',
@@ -148,7 +153,7 @@ const Gallery: React.FC<GalleryProps> = ({ images, fetchNextPage, hasNextPage, i
           </DialogTitle>
             <Box
               component="img"
-              src={selectedImage.url}
+              src={fullImageUrl}
               alt={selectedImage.publicId}
               sx={{
                 

--- a/frontend/src/components/ImageCard.tsx
+++ b/frontend/src/components/ImageCard.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Card, CardMedia, Typography, Box } from '@mui/material';
 import { ImageCardProps } from '../types';
 
+const BASE_URL = import.meta.env.VITE_API_URL;
 const ImageCard: React.FC<ImageCardProps> = ({ image, onClick }) => {
+  const fullImageUrl = image.url.startsWith('http') ? image.url : `${BASE_URL}${image.url}`;
   return (
     <Card
       onClick={() => onClick(image)}
@@ -18,7 +20,7 @@ const ImageCard: React.FC<ImageCardProps> = ({ image, onClick }) => {
     >
       <CardMedia
         component="img"
-        image={image.url}
+        image={fullImageUrl}
         alt={`Gallery item ${image.id}`}
         sx={{
           width: '100%',

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,18 +1,20 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react-swc';
 
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  esbuild: false,
-  //configure a proxy to avoid CORS issues during development
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-        secure: false,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [react()],
+    esbuild: false,
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL || 'http://localhost:3000',
+          changeOrigin: true,
+          secure: false,
+        },
       },
     },
-  },
-})
+  };
+});


### PR DESCRIPTION
The app now uses local storage if Cloudinary credentials are not provided in the .env file. 

 - Added a LocalStorage service.
 - CloudinaryService and LocalStorage service both implement IImageStorage interface.
 - During initial app initialization, a check is performed within the TSyringe dependency container, checking if Cloudinary is set up in the .env file. It creates ImageStorageService and initializes it with either CloudinaryService or LocalStorageService. 
 - It now injects ImageStorageService throughout the app. 
 - Uploads are stored in /uploads directory in /backend and served to the frontend. 
 - In the frontend, this case is handled by appending the backend localhost url to the image url as the incoming image url is now different. 
 - **The uploads directory is non-persistent in docker**. Upon container restart, the uploads are lost. It could be made persistent by binding a docker volume to the directory in docker-compose, like so: 
  ``` 
  - volumes:
      - ./uploads:/backend/uploads
   ```
   Don't think it's necessary since this is just to make it easier to run local.
  - **Because it only uses localhost, images uploaded locally can't be served when the app is used from the local network**. 
    -  For example, when exposing it to local network with `vite --host`, images uploaded locally are only visible to the localhost. Devices accessing it from the network can't view them.  