### PR TITLE
fix: Selecting conversation would cause an infinite loop

### DIFF
--- a/frontend/src/screens/Messages.tsx
+++ b/frontend/src/screens/Messages.tsx
@@ -67,68 +67,46 @@ const getConversationAvatar = (conversation: ConversationSummaryDTO, currentUser
 
 const Messages = () => {
 	const theme = useTheme();
-	const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-	const { user } = useAuth();
 	const location = useLocation();
 	const navigate = useNavigate();
-	const conversationParam = useMemo(() => {
+	const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+	const [draftBody, setDraftBody] = useState("");
+	const { user } = useAuth();
+	const messagesContainerRef = useRef<HTMLDivElement | null>(null);
+	const [showConversationsOnMobile, setShowConversationsOnMobile] = useState(true);
+	const lastMessageCountRef = useRef<number>(0);
+	const conversationsQuery = useConversations();
+
+	const conversations = useMemo(
+		() => conversationsQuery.data?.pages.flatMap((p) => p.conversations) ?? [],
+		[conversationsQuery.data]
+	);
+
+	const selectedConversationId = useMemo(() => {
 		const params = new URLSearchParams(location.search);
 		return params.get("conversation");
 	}, [location.search]);
 
-	const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
-	const [draftBody, setDraftBody] = useState("");
-	const [showConversationsOnMobile, setShowConversationsOnMobile] = useState(true);
-	const lastReadRef = useRef<string | null>(null);
-	const messagesContainerRef = useRef<HTMLDivElement | null>(null);
-	const lastMessageCountRef = useRef<number>(0);
-
-	const conversationsQuery = useConversations();
-	const conversations = useMemo(() => {
-		const pages = conversationsQuery.data?.pages ?? [];
-		return pages.flatMap((page) => page.conversations);
-	}, [conversationsQuery.data?.pages]);
-
 	useEffect(() => {
-		if (conversationParam) {
-			if (conversationParam !== selectedConversationId) {
-				setSelectedConversationId(conversationParam);
-			}
-			if (isMobile) {
-				setShowConversationsOnMobile(false);
-			}
-			return;
-		}
-
 		if (!selectedConversationId && conversations.length > 0) {
-			setSelectedConversationId(conversations[0].publicId);
+			navigate(`?conversation=${conversations[0].publicId}`, { replace: true });
 		}
-	}, [conversationParam, conversations, selectedConversationId, isMobile]);
-
-	useEffect(() => {
-		if (!selectedConversationId && !conversationParam) {
-			return;
-		}
-
-		if (selectedConversationId === conversationParam) {
-			return;
-		}
-
-		const search = selectedConversationId ? `?conversation=${selectedConversationId}` : "";
-		navigate({ pathname: location.pathname, search }, { replace: true });
-	}, [selectedConversationId, conversationParam, navigate, location.pathname]);
+	}, [conversations, selectedConversationId, navigate]);
 
 	const markConversationRead = useMarkConversationRead();
+	const selectedConversation = useMemo(() => {
+		return conversations.find((c) => c.publicId === selectedConversationId);
+	}, [conversations, selectedConversationId]);
 
+	// This effect for marking as read remains.
 	useEffect(() => {
-		if (!selectedConversationId) return;
-		if (lastReadRef.current === selectedConversationId) return;
-
-		markConversationRead.mutate(selectedConversationId);
-		lastReadRef.current = selectedConversationId;
-	}, [selectedConversationId, markConversationRead]);
+		if (selectedConversation && selectedConversation.unreadCount > 0) {
+			markConversationRead.mutate(selectedConversation.publicId);
+		}
+	}, [selectedConversation, markConversationRead]);
 
 	const messagesQuery = useConversationMessages(selectedConversationId);
+
 	const messages = useMemo(() => {
 		const pages = messagesQuery.data?.pages ?? [];
 		const flattened = pages.flatMap((page) => page.messages);
@@ -150,6 +128,12 @@ const Messages = () => {
 
 	const sendMessage = useSendMessage();
 
+	const handleSelectConversation = (conversationId: string) => {
+		navigate(`?conversation=${conversationId}`);
+		if (isMobile) {
+			setShowConversationsOnMobile(false);
+		}
+	};
 	const handleSendMessage = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		if (!draftBody.trim() || !selectedConversationId) return;
@@ -168,13 +152,6 @@ const Messages = () => {
 				});
 			}
 		});
-	};
-
-	const handleSelectConversation = (conversationId: string) => {
-		setSelectedConversationId(conversationId);
-		if (isMobile) {
-			setShowConversationsOnMobile(false);
-		}
 	};
 
 	const handleBackToList = () => {


### PR DESCRIPTION
When selecting conversations, 2 conflicting useEffect hooks in the Messaging screen would cause an infinite loop due to a race condition
 - The page loads and `selectedConversationId` is "X", `markConversationRead` effect fires for "X" - the mutation succeeds and the `setQueryData` successfully updates the cache setting "X.unreadCount" to 0. The UI updates and everything seems stable 
 - The user clicks conversation "Y", chaos ensues:  `handleSelectConversation("Y")` runs, `setSelectedConversationId("Y")` is called and the component re-renders. `selectedConversationId` is now "Y";
 - "Mark as read" effect hits:  the `useEffect` for marking messages as read runs because `selectedConversationId` changed from "X" to "Y". ` markConversationRead.mutate("Y")` is called. X POST request is sent to the backend for conversation Y
 - The "URL Sync" effect fires: simultaneously, the other `useEffect` that syncs the URL also runs because `selectedConversationId` changed. `navigate({ ... search: "?conversation=Y" })` is called.
 - The Mutation for "Y" Succeeds: `onSuccess` callback in `useMarkConversationRead` runs. `queryClient.setQueryData(...)` is called. It updates the cache, setting `Y.unreadCount` to 0. 
 **_- Because the query data for `useConversations` has changed, the hook returns a new conversations array object._**
 - The loop trigger: Messages component re-renders because it received a new conversations array. `useEffect` that syncs state from the URL and conversations runs again because conversations is one of its dependencies.
 - The loop repeats sending countless requests to the backend, causing mongo transaction errors. 
 