### PR TITLE
fix: Definitive fix for conversations.

### DIFF
--- a/frontend/src/api/messagingApi.ts
+++ b/frontend/src/api/messagingApi.ts
@@ -1,32 +1,11 @@
 import axiosClient from "./axiosClient";
-import { ConversationSummaryDTO, MessageDTO, MessageAttachment } from "../types";
-
-export interface ConversationListResponse {
-	conversations: ConversationSummaryDTO[];
-	total: number;
-	page: number;
-	limit: number;
-	totalPages: number;
-}
-
-export interface ConversationMessagesResponse {
-	messages: MessageDTO[];
-	total: number;
-	page: number;
-	limit: number;
-	totalPages: number;
-}
-
-export interface SendMessageRequest {
-	conversationPublicId?: string;
-	recipientPublicId?: string;
-	body: string;
-	attachments?: MessageAttachment[];
-}
-
-export interface InitiateConversationResponse {
-	conversation: ConversationSummaryDTO;
-}
+import {
+	SendMessageRequest,
+	MessageDTO,
+	InitiateConversationResponse,
+	ConversationListResponse,
+	ConversationMessagesResponse,
+} from "@/types";
 
 export const fetchConversations = async (
 	params: { page?: number; limit?: number } = {}

--- a/frontend/src/hooks/messaging/useConversationMessages.ts
+++ b/frontend/src/hooks/messaging/useConversationMessages.ts
@@ -1,5 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { fetchConversationMessages, ConversationMessagesResponse } from "../../api/messagingApi";
+import { fetchConversationMessages } from "../../api/messagingApi";
+import { ConversationMessagesResponse } from "@/types";
 
 const DEFAULT_PAGE_SIZE = 30;
 

--- a/frontend/src/hooks/messaging/useConversations.ts
+++ b/frontend/src/hooks/messaging/useConversations.ts
@@ -1,5 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { fetchConversations, ConversationListResponse } from "../../api/messagingApi";
+import { fetchConversations } from "../../api/messagingApi";
+import { ConversationListResponse } from "@/types";
 
 const DEFAULT_PAGE_SIZE = 20;
 

--- a/frontend/src/hooks/messaging/useInitiateConversation.ts
+++ b/frontend/src/hooks/messaging/useInitiateConversation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { initiateConversation, InitiateConversationResponse } from "../../api/messagingApi";
+import { initiateConversation } from "../../api/messagingApi";
+import { InitiateConversationResponse } from "@/types";
 
 export function useInitiateConversation() {
 	const queryClient = useQueryClient();

--- a/frontend/src/hooks/messaging/useMarkConversationRead.ts
+++ b/frontend/src/hooks/messaging/useMarkConversationRead.ts
@@ -1,14 +1,35 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
 import { markConversationRead } from "../../api/messagingApi";
+import type { ConversationListResponse } from "../../types";
 
 export function useMarkConversationRead() {
 	const queryClient = useQueryClient();
 
 	return useMutation({
 		mutationFn: (conversationPublicId: string) => markConversationRead(conversationPublicId),
+
 		onSuccess: (_data, conversationPublicId) => {
-			queryClient.invalidateQueries({ queryKey: ["messaging", "conversations"] });
-			queryClient.invalidateQueries({ queryKey: ["messaging", "conversation", conversationPublicId] });
+			// manually update the cache for the conversation list without invalidating
+			// this prevents refetching and breaking the infinite loop
+			queryClient.setQueriesData<InfiniteData<ConversationListResponse>>(
+				{ queryKey: ["messaging", "conversations"], exact: false },
+				(oldData) => {
+					if (!oldData) return oldData;
+
+					return {
+						...oldData,
+						pages: oldData.pages.map((page) => ({
+							...page,
+							conversations: page.conversations.map((convo) => {
+								if (convo.publicId === conversationPublicId) {
+									return { ...convo, unreadCount: 0 };
+								}
+								return convo;
+							}),
+						})),
+					};
+				}
+			);
 		},
 	});
 }

--- a/frontend/src/hooks/messaging/useSendMessage.ts
+++ b/frontend/src/hooks/messaging/useSendMessage.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { sendMessage, SendMessageRequest } from "../../api/messagingApi";
+import { sendMessage } from "../../api/messagingApi";
+import { SendMessageRequest } from "@/types";
 
 export function useSendMessage() {
 	const queryClient = useQueryClient();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -279,3 +279,30 @@ export interface AuthFormProps<T> {
 	linkTo?: string;
 	initialValues?: Partial<T>;
 }
+
+export interface ConversationListResponse {
+	conversations: ConversationSummaryDTO[];
+	total: number;
+	page: number;
+	limit: number;
+	totalPages: number;
+}
+
+export interface ConversationMessagesResponse {
+	messages: MessageDTO[];
+	total: number;
+	page: number;
+	limit: number;
+	totalPages: number;
+}
+
+export interface SendMessageRequest {
+	conversationPublicId?: string;
+	recipientPublicId?: string;
+	body: string;
+	attachments?: MessageAttachment[];
+}
+
+export interface InitiateConversationResponse {
+	conversation: ConversationSummaryDTO;
+}


### PR DESCRIPTION
- `useMarkConversationsRead` was a part of the problem. Now it manually updates the conversation and messaging cache without invalidation which prevents the infinite loop
- Also the `useEffect` marking messages as read needed to be improved: used markAsReadRef with the useRef holding a Set<string>. Updates of the set don't trigger re-renders and makes tracking easier. 