### PR TITLE
Aggregation pipelines optimization

### DIFF
--- a/api-gateway/src/server.ts
+++ b/api-gateway/src/server.ts
@@ -4,7 +4,7 @@ import http from "http";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
-import { createProxyMiddleware, Options } from "http-proxy-middleware";
+import { createProxyMiddleware } from "http-proxy-middleware";
 import { config } from "./config.js";
 
 const app = express();

--- a/backend/src/models/conversation.model.ts
+++ b/backend/src/models/conversation.model.ts
@@ -13,7 +13,6 @@ const conversationSchema = new Schema<IConversation>(
 		participantHash: {
 			type: String,
 			required: true,
-			index: true,
 		},
 		participants: [
 			{

--- a/backend/src/models/favorite.model.ts
+++ b/backend/src/models/favorite.model.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema, Document } from "mongoose";
+import mongoose, { Schema } from "mongoose";
 import { IFavorite } from "types/index";
 
 const favoriteSchema = new Schema<IFavorite>(
@@ -18,7 +18,7 @@ const favoriteSchema = new Schema<IFavorite>(
 );
 
 favoriteSchema.index({ userId: 1, imageId: 1 }, { unique: true }); // compound index to ensure a user can only favorite an image once
-favoriteSchema.index({ userId: 1, createdAt: -1 }); // index to efficiently query for a user's favorites, sorted by most recent
+favoriteSchema.index({ userId: 1, createdAt: -1 }); // compound index to efficiently query for a user's favorites, sorted by most recent
 
 const Favorite = mongoose.model<IFavorite>("Favorite", favoriteSchema);
 export default Favorite;

--- a/backend/src/models/image.model.ts
+++ b/backend/src/models/image.model.ts
@@ -2,13 +2,14 @@ import mongoose, { Schema } from "mongoose";
 import { IImage, ITag } from "../types";
 import User from "./user.model";
 import { v4 as uuidv4 } from "uuid";
+import { create } from "domain";
 
 const imageSchema = new Schema<IImage>({
 	url: { type: String, required: true },
 	publicId: {
 		type: String,
 		required: true,
-		unique: true,
+		unique: true, // Defult index
 		default: uuidv4(),
 		immutable: true,
 	},
@@ -190,9 +191,14 @@ imageSchema.pre("deleteMany", async function (next) {
 });
 
 imageSchema.index({ user: 1 });
+imageSchema.index({ createdAt: -1 });
 imageSchema.index({ tags: 1 });
+imageSchema.index({ user: 1, createdAt: -1 }); // compound index for querying images by user and sorting by most recent
+
 imageSchema.index({ tags: "text", user: "text" });
+
 tagSchema.index({ tag: "text" });
+tagSchema.index({ tags: 1, modifiedAt: -1 }); // compound index to efficiently query for images by tag, sorted by most recent
 console.log("Defining Image model");
 const Image = mongoose.model<IImage>("Image", imageSchema);
 export const Tag = mongoose.model("Tag", tagSchema);

--- a/backend/src/services/image.service.ts
+++ b/backend/src/services/image.service.ts
@@ -378,6 +378,7 @@ export class ImageService {
 
 	/**
 	 * Private helper method to check if a user has liked a specific image
+	 * @private
 	 */
 	private async checkIfUserLikedImage(userPublicId: string, imageId: string): Promise<boolean> {
 		try {


### PR DESCRIPTION
 - Added missing indices
 - Examined the aggregation pipelines using .explain() and improved their efficiency by resolving favorite tags to objectIDs up front, computing scores directly on image docs and deferring both image and user $lookup after sorting and skipping. This avoids the collection-wide $lookup before pagination 
 - The rank calculations no only touch core fields and stages that need to read every document do less per-doc work especially when there are no tag preferences for the user. 
 - `COLLSCAN` still happens because I can't leverage index when sorting by a computed `rankScore` but that's good enough for the time being. If it ever becomes a bottleneck i'll try denormalizing the score or materializing lightweight snapshots  