### PR TITLE
Node.js DNS resolution bugfix

### DIFF
--- a/api-gateway/src/server.ts
+++ b/api-gateway/src/server.ts
@@ -1,4 +1,5 @@
 import { IncomingMessage } from "http";
+import dns from 'node:dns';
 import { Socket } from "net";
 import http from "http";
 import express, { Request, Response, NextFunction } from "express";
@@ -7,7 +8,7 @@ import rateLimit from "express-rate-limit";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { config } from "./config.js";
 import client from "prom-client";
-
+dns.setServers(['8.8.8.8', '1.1.1.1']);
 const app = express();
 const metricsRegistry = new client.Registry();
 metricsRegistry.setDefaultLabels({ service: "api-gateway" });

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+import dns from 'node:dns';
 import { errorLogger, logger } from "./utils/winston";
 import mongoose from "mongoose";
 import dotenv from "dotenv";
@@ -30,6 +31,7 @@ import { TrendingWorker } from "./workers/_impl/trending.worker.impl";
 import { ProfileSyncWorker } from "./workers/_impl/profile-sync.worker.impl";
 import { NewFeedWarmCacheWorker } from "./workers/_impl/newFeedWarmCache.worker.impl";
 
+dns.setServers(['8.8.8.8', '1.1.1.1']);
 // Global error handlers
 process.on("uncaughtException", (error: Error) => {
 	errorLogger.error({

--- a/backend/src/server/server.ts
+++ b/backend/src/server/server.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import express, { Application } from "express";
 import cookieParser from "cookie-parser";
 import http from "http";
+
 import helmet from "helmet";
 import { injectable, inject } from "tsyringe";
 import { UserRoutes } from "../routes/user.routes";

--- a/backend/src/workers/newFeedWarmCache.worker.ts
+++ b/backend/src/workers/newFeedWarmCache.worker.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import path from "path";
 import dotenv from "dotenv";
 import { logger } from "@/utils/winston";
-
+import dns from 'node:dns';
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 logger.info("MONGODB_URI in worker:", { uri: process.env.MONGODB_URI });
@@ -13,6 +13,7 @@ import { DatabaseConfig } from "@/config/dbConfig";
 import { NewFeedWarmCacheWorker } from "../workers/_impl/newFeedWarmCache.worker.impl";
 
 const worker = new NewFeedWarmCacheWorker();
+dns.setServers(['8.8.8.8', '1.1.1.1']);
 
 async function start() {
 	try {

--- a/backend/src/workers/profile-sync.worker.ts
+++ b/backend/src/workers/profile-sync.worker.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import path from "path";
 import dotenv from "dotenv";
 import { logger } from "@/utils/winston";
-
+import dns from 'node:dns';
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import { container } from "tsyringe";
@@ -11,6 +11,7 @@ import { DatabaseConfig } from "@/config/dbConfig";
 import { ProfileSyncWorker } from "./_impl/profile-sync.worker.impl";
 
 const worker = new ProfileSyncWorker();
+dns.setServers(['8.8.8.8', '1.1.1.1']);
 
 async function start() {
 	try {

--- a/backend/src/workers/trending.worker.ts
+++ b/backend/src/workers/trending.worker.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import path from "path";
 import dotenv from "dotenv";
 import { logger } from "@/utils/winston";
-
+import dns from 'node:dns';
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 logger.info("MONGODB_URI in worker:", { uri: process.env.MONGODB_URI });
@@ -13,7 +13,7 @@ import { DatabaseConfig } from "@/config/dbConfig";
 import { TrendingWorker } from "../workers/_impl/trending.worker.impl";
 
 const worker = new TrendingWorker();
-
+dns.setServers(['8.8.8.8', '1.1.1.1']);
 async function start() {
 	try {
 		// register core DI entries (models, repos, services, controllers, routes)


### PR DESCRIPTION
- After updating Node and NPM, Node can no longer properly resolve DNS for the mongodb atlas connection string. the only fix(i managed to pull of) was manually setting dns.setServers(['8.8.8.8', '1.1.1.1']); in every file that connects to mongodb atlas.