### PR TITLE
fix: image upload consistency refactor using a hybrid apprach

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches: ["master"]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,7 +29,7 @@ jobs:
           context: .
           file: ./frontend/frontend.Dockerfile
           push: true
-          tags: ghcr.io/danzin/photoapp-frontend:latest
+          tags: ghcr.io/sunsetstack/ascendance-frontend:latest
           build-args: |
             VITE_API_URL=/
             VITE_SOCKET_URL=/
@@ -35,12 +40,14 @@ jobs:
           context: .
           file: ./backend/backend.Dockerfile
           push: true
-          tags: ghcr.io/danzin/photoapp-backend:latest
+          tags: ghcr.io/sunsetstack/ascendance-backend:latest
+
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+
     steps:
-      - name: Deploy to Digital Ocean via SSH
+      - name: Deploy to DigitalOcean via SSH
         uses: appleboy/ssh-action@v1.0.3
         env:
           REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
@@ -51,7 +58,7 @@ jobs:
           port: 22
           envs: REDIS_PASSWORD
           script: |
-            cd /opt/image-app
+            cd /opt/ascendance-social
 
             touch .env
             if grep -q '^REDIS_PASSWORD=' .env; then
@@ -60,9 +67,8 @@ jobs:
               echo "REDIS_PASSWORD=${REDIS_PASSWORD}" >> .env
             fi
 
-            git fetch --all
+            git fetch origin master
             git reset --hard origin/master
-            git pull origin master
 
             docker-compose -f docker-compose-prod.yml pull
             docker-compose -f docker-compose-prod.yml up -d

--- a/backend/src/__tests__/commands/post/createPost.handler.test.ts
+++ b/backend/src/__tests__/commands/post/createPost.handler.test.ts
@@ -25,6 +25,8 @@ describe("CreatePostCommandHandler", () => {
 	};
 	let mockPostWriteRepository: {
 		create: SinonStub;
+		activatePendingPost: SinonStub;
+		updatePostStatus: SinonStub;
 	};
 	let mockUserReadRepository: {
 		findByPublicId: SinonStub;
@@ -57,6 +59,7 @@ describe("CreatePostCommandHandler", () => {
 	};
 	let mockEventBus: {
 		queueTransactional: SinonStub;
+		queueDurable: SinonStub;
 		publish: SinonStub;
 	};
 	let mockSession: ClientSession;
@@ -75,6 +78,8 @@ describe("CreatePostCommandHandler", () => {
 
 		mockPostWriteRepository = {
 			create: sinon.stub(),
+			activatePendingPost: sinon.stub(),
+			updatePostStatus: sinon.stub(),
 		};
 
 		mockUserReadRepository = {
@@ -105,6 +110,7 @@ describe("CreatePostCommandHandler", () => {
 			deleteImage: sinon.stub(),
 			rollbackUpload: sinon.stub(),
 			uploadImage: sinon.stub(),
+			uploadImageStream: sinon.stub(),
 			createImageRecord: sinon.stub(),
 		};
 
@@ -115,6 +121,7 @@ describe("CreatePostCommandHandler", () => {
 
 		mockEventBus = {
 			queueTransactional: sinon.stub(),
+			queueDurable: sinon.stub(),
 			publish: sinon.stub(),
 		};
 
@@ -227,6 +234,7 @@ describe("CreatePostCommandHandler", () => {
 			mockImageService.createImageRecord.resolves(mockImageResponse);
 
 			mockPostWriteRepository.create.resolves(mockCreatedPost);
+			mockPostWriteRepository.activatePendingPost.resolves(mockCreatedPost);
 			mockPostReadRepository.findByPublicId.resolves(mockHydratedPost);
 
 			const mockPostDTO = {
@@ -257,6 +265,7 @@ describe("CreatePostCommandHandler", () => {
 			expect(mockImageService.createImageRecord.called).to.be.true;
 
 			expect(mockPostWriteRepository.create.called).to.be.true;
+			expect(mockPostWriteRepository.activatePendingPost.called).to.be.true;
 			expect(mockUnitOfWork.executeInTransaction.called).to.be.true;
 			expect(mockDTOService.toPostDTO.calledWith(mockHydratedPost)).to.be.true;
 			expect(result).to.equal(mockPostDTO);
@@ -311,6 +320,7 @@ describe("CreatePostCommandHandler", () => {
 			mockImageService.createImageRecord.resolves(mockImageSummary);
 
 			mockPostWriteRepository.create.resolves(mockCreatedPost);
+			mockPostWriteRepository.activatePendingPost.resolves(mockCreatedPost);
 			mockPostReadRepository.findByPublicId.resolves(mockHydratedPost);
 
 			mockUnitOfWork.executeInTransaction.callsFake(async (callback) => {

--- a/backend/src/__tests__/commands/post/deletePost.handler.test.ts
+++ b/backend/src/__tests__/commands/post/deletePost.handler.test.ts
@@ -46,9 +46,6 @@ describe("DeletePostCommandHandler", () => {
 		removePostAttachmentRecord: SinonStub;
 		deleteAttachmentAsset: SinonStub;
 	};
-	let mockRetryService: {
-		execute: SinonStub;
-	};
 	let mockRedisService: {
 		invalidateFeed: SinonStub;
 		invalidateByTags: SinonStub;
@@ -100,10 +97,6 @@ describe("DeletePostCommandHandler", () => {
 			deleteAttachmentAsset: sinon.stub().resolves(),
 		};
 
-		mockRetryService = {
-			execute: sinon.stub().callsFake(async (op: () => Promise<unknown>) => op()),
-		};
-
 		mockRedisService = {
 			invalidateFeed: sinon.stub(),
 			invalidateByTags: sinon.stub().resolves(),
@@ -127,8 +120,6 @@ describe("DeletePostCommandHandler", () => {
 			mockCommunityMemberRepository as any,
 			mockTagService as any,
 			mockImageService as any,
-			mockRedisService as any,
-			mockRetryService as any,
 			mockEventBus as any,
 		);
 
@@ -216,8 +207,7 @@ describe("DeletePostCommandHandler", () => {
 			expect(mockPostReadRepository.findByPublicId.calledWith(VALID_POST_PUBLIC_ID)).to.be.true;
 			expect(mockUserReadRepository.findByPublicId.calledWith(VALID_USER_PUBLIC_ID)).to.be.true;
 			expect(mockImageService.removePostAttachmentRecord.called).to.be.true;
-			expect(mockRetryService.execute.called).to.be.true;
-			expect(mockImageService.deleteAttachmentAsset.called).to.be.true;
+			expect(mockImageService.deleteAttachmentAsset.called).to.be.false;
 			expect(mockTagService.decrementUsage.calledOnce).to.be.true;
 			expect(mockTagService.decrementUsage.firstCall.args[0]).to.deep.equal(mockTagIds);
 			expect(mockPostWriteRepository.delete.called).to.be.true;
@@ -258,7 +248,6 @@ describe("DeletePostCommandHandler", () => {
 			await handler.execute(command);
 
 			expect(mockImageService.removePostAttachmentRecord.called).to.be.false;
-			expect(mockRetryService.execute.called).to.be.false;
 			expect(mockTagService.decrementUsage.calledOnce).to.be.true;
 			expect(mockTagService.decrementUsage.firstCall.args[0]).to.deep.equal(mockTagIds);
 			expect(mockPostWriteRepository.delete.called).to.be.true;
@@ -298,7 +287,7 @@ describe("DeletePostCommandHandler", () => {
 			expect(mockPostWriteRepository.delete.called).to.be.true;
 		});
 
-		it("should continue post deletion even if image deletion fails", async () => {
+		it("should abort post deletion if image record deletion fails", async () => {
 			const mockUserId = new Types.ObjectId();
 			const mockTagIds = [new Types.ObjectId()];
 
@@ -328,11 +317,12 @@ describe("DeletePostCommandHandler", () => {
 				return await callback(mockSession);
 			});
 
-			const result = await handler.execute(command);
+			await expect(handler.execute(command)).to.be.rejectedWith(
+				"Image service unavailable",
+			);
 
-			expect(mockPostWriteRepository.delete.called).to.be.true;
-			expect(mockTagService.decrementUsage.called).to.be.true;
-			expect(result).to.have.property("message", "Post deleted successfully");
+			expect(mockPostWriteRepository.delete.called).to.be.false;
+			expect(mockTagService.decrementUsage.called).to.be.false;
 		});
 
 		it("should queue PostDeletedEvent after successful deletion", async () => {
@@ -366,10 +356,10 @@ describe("DeletePostCommandHandler", () => {
 
 			await handler.execute(command);
 
-			expect(mockEventBus.publish.calledOnce).to.be.true;
+			expect(mockEventBus.queueTransactional.called).to.be.true;
 		});
 
-		it("should invalidate user feed cache after deletion", async () => {
+		it("should not invalidate user feed cache inline after deletion", async () => {
 			const mockUserId = new Types.ObjectId();
 
 			const mockUser = {
@@ -398,8 +388,8 @@ describe("DeletePostCommandHandler", () => {
 
 			await handler.execute(command);
 
-			expect(mockRedisService.invalidateByTags.calledWith([`user_feed:${VALID_USER_PUBLIC_ID}`])).to.be.true;
-			expect(mockRedisService.zrem.calledOnceWith("trending:posts", VALID_POST_PUBLIC_ID)).to.be.true;
+			expect(mockRedisService.invalidateByTags.called).to.be.false;
+			expect(mockRedisService.zrem.called).to.be.false;
 		});
 	});
 });

--- a/backend/src/application/commands/post/createPost/createPost.handler.ts
+++ b/backend/src/application/commands/post/createPost/createPost.handler.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "tsyringe";
 import {
   CommunityPublicId,
+  asMongoId,
   asPostPublicId,
   asCommunityPublicId,
   asUserPublicId,
@@ -23,6 +24,7 @@ import { DTOService } from "@/services/dto.service";
 import { UnitOfWork } from "@/database/UnitOfWork";
 import { EventBus } from "@/application/common/buses/event.bus";
 import { PostUploadedEvent } from "@/application/events/post/post.event";
+import { ImageAssetCleanupRequestedEvent } from "@/application/events/image/image.event";
 import { NotificationRequestedEvent } from "@/application/events/notification/notification.event";
 import {
   PostNotFoundError,
@@ -84,11 +86,13 @@ export class CreatePostCommandHandler implements ICommandHandler<
     }
 
     let uploadResult: { url: string; publicId: string } | null = null;
-    let transactionCommitted = false;
+    let pendingPostId: mongoose.Types.ObjectId | null = null;
+    let activated = false;
 
     try {
       // ── Phase 1: pre-commit work ──────────────────────────────────────────
       const user = await this.validateUser(command.userPublicId);
+      const normalizedBody = this.normalizeBody(command.body);
 
       let communityInternalId: Types.ObjectId | null = null;
       if (command.communityPublicId) {
@@ -109,6 +113,11 @@ export class CreatePostCommandHandler implements ICommandHandler<
         communityInternalId = communityId;
       }
 
+      const pendingPost = await this.unitOfWork.executeInTransaction(() =>
+        this.createPendingPost(user, normalizedBody, communityInternalId),
+      );
+      pendingPostId = pendingPost._id as mongoose.Types.ObjectId;
+
       const strategy = ImageUploadStrategySelector.from(
         command,
         this.imageService,
@@ -126,25 +135,30 @@ export class CreatePostCommandHandler implements ICommandHandler<
       }
 
       const txResult = await this.unitOfWork.executeInTransaction(async () =>
-        this.runTransaction(command, user, communityInternalId, uploadResult),
+        this.activatePendingPost(
+          command,
+          user,
+          communityInternalId,
+          uploadResult,
+          pendingPost,
+          normalizedBody,
+        ),
       );
 
       // Commit boundary - errors after this line must NOT trigger compensation
-      transactionCommitted = true;
+      activated = true;
 
       // ── Phase 2: post-commit (non-compensable) ────────────────────────────
       return await this.finalizePost(txResult);
     } catch (error) {
-      // Only compensate if the transaction never committed
-      if (!transactionCommitted && uploadResult) {
-        await this.imageService
-          .rollbackUpload(uploadResult.publicId)
-          .catch((e) => {
-            logger.error(
-              "[CreatePostCommandHandler] Image rollback failed after transaction error",
-              { error: e },
-            );
-          });
+      // Only compensate if the post never became active.
+      if (!activated) {
+        if (uploadResult) {
+          await this.requestUploadedAssetCleanup(uploadResult.publicId);
+        }
+        if (pendingPostId) {
+          await this.markPendingPostFailed(pendingPostId, error);
+        }
       }
       throw mapPostError(error, {
         action: "create-post",
@@ -184,14 +198,47 @@ export class CreatePostCommandHandler implements ICommandHandler<
     return { communityId };
   }
 
-  private async runTransaction(
+  private async createPendingPost(
+    user: IUser,
+    normalizedBody: string,
+    communityId: Types.ObjectId | null,
+  ): Promise<IPost> {
+    const internalUserId = user._id as mongoose.Types.ObjectId;
+
+    const payload: Partial<IPost> = {
+      publicId: asPostPublicId(uuidv4()),
+      user: internalUserId,
+      author: {
+        _id: internalUserId,
+        publicId: user.publicId,
+        handle: user.handle,
+        username: user.username,
+        avatarUrl: user.avatar ?? "",
+        displayName: user.username,
+      },
+      body: normalizedBody,
+      image: null,
+      tags: [],
+      likesCount: 0,
+      commentsCount: 0,
+      status: "pending",
+      ...(communityId ? { communityId } : {}),
+    };
+
+    return this.postWriteRepository.create(
+      sanitizeForMongo(payload) as unknown as IPost,
+    );
+  }
+
+  private async activatePendingPost(
     command: CreatePostCommand,
     user: IUser,
     communityInternalId: Types.ObjectId | null,
     uploadResult: { url: string; publicId: string } | null,
+    pendingPost: IPost,
+    normalizedBody: string,
   ): Promise<TransactionResult> {
     const internalUserId = user._id as mongoose.Types.ObjectId;
-    const normalizedBody = this.normalizeBody(command.body);
 
     const tagNames = this.tagService.collectTagNames(
       normalizedBody,
@@ -211,13 +258,20 @@ export class CreatePostCommandHandler implements ICommandHandler<
     );
 
     const post = await this.buildPost(
-      user,
-      internalUserId,
+      pendingPost,
       normalizedBody,
       tagIds,
       imageSummary,
-      communityInternalId,
     );
+
+    if (!post) {
+      throw Errors.conflict("Pending post could not be activated", {
+        context: {
+          operation: "activatePendingPost",
+          postId: pendingPost._id?.toString(),
+        },
+      });
+    }
 
     if (!communityInternalId) {
       await this.userWriteRepository.update(user.id, {
@@ -262,39 +316,22 @@ export class CreatePostCommandHandler implements ICommandHandler<
   }
 
   private async buildPost(
-    user: IUser,
-    internalUserId: mongoose.Types.ObjectId,
+    pendingPost: IPost,
     normalizedBody: string,
     tagIds: mongoose.Types.ObjectId[],
     imageSummary: AttachmentSummary,
-    communityId: Types.ObjectId | null,
-  ): Promise<IPost> {
+  ): Promise<IPost | null> {
     const postSlug =
       imageSummary.slug ??
       `${generateSlug(normalizedBody, 60) || "post"}-${Date.now()}`;
 
-    const payload: Partial<IPost> = {
-      publicId: asPostPublicId(uuidv4()),
-      user: internalUserId,
-      author: {
-        _id: internalUserId,
-        publicId: user.publicId,
-        handle: user.handle,
-        username: user.username,
-        avatarUrl: user.avatar ?? "",
-        displayName: user.username,
+    return this.postWriteRepository.activatePendingPost(
+      asMongoId(pendingPost._id!.toString()),
+      {
+        image: imageSummary.docId,
+        tags: tagIds,
+        slug: postSlug,
       },
-      body: normalizedBody,
-      slug: postSlug,
-      image: imageSummary.docId,
-      tags: tagIds,
-      likesCount: 0,
-      commentsCount: 0,
-      ...(communityId ? { communityId } : {}),
-    };
-
-    return this.postWriteRepository.create(
-      sanitizeForMongo(payload) as unknown as IPost,
     );
   }
 
@@ -347,6 +384,45 @@ export class CreatePostCommandHandler implements ICommandHandler<
     ]);
 
     return this.dtoService.toPostDTO(hydratedPost);
+  }
+
+  private async requestUploadedAssetCleanup(storagePublicId: string): Promise<void> {
+    await this.eventBus
+      .queueDurable(
+        new ImageAssetCleanupRequestedEvent(
+          "create-post-activation-failed",
+          storagePublicId,
+        ),
+      )
+      .catch((error) => {
+        logger.error(
+          "[CreatePostCommandHandler] Failed to queue durable image cleanup",
+          { error, storagePublicId },
+        );
+      });
+
+    await this.imageService.rollbackUpload(storagePublicId);
+  }
+
+  private async markPendingPostFailed(
+    postId: mongoose.Types.ObjectId,
+    error: unknown,
+  ): Promise<void> {
+    const failureReason = error instanceof Error ? error.message : String(error);
+    await this.unitOfWork
+      .executeInTransaction(() =>
+        this.postWriteRepository.updatePostStatus(
+          asMongoId(postId.toString()),
+          "failed",
+          failureReason.substring(0, 500),
+        ),
+      )
+      .catch((markError) => {
+        logger.error("[CreatePostCommandHandler] Failed to mark post failed", {
+          postId: postId.toString(),
+          error: markError,
+        });
+      });
   }
 
   private normalizeBody(body?: string): string {

--- a/backend/src/application/commands/post/deletePost/deletePost.handler.ts
+++ b/backend/src/application/commands/post/deletePost/deletePost.handler.ts
@@ -17,11 +17,10 @@ import { CommentRepository } from "@/repositories/comment.repository";
 import { CommunityMemberRepository } from "@/repositories/communityMember.repository";
 import { TagService } from "@/services/tag.service";
 import { ImageService } from "@/services/image.service";
-import { RedisService } from "@/services/redis.service";
-import { RetryPresets, RetryService } from "@/services/retry.service";
 import { UnitOfWork } from "@/database/UnitOfWork";
 import { EventBus } from "@/application/common/buses/event.bus";
 import { PostDeletedEvent } from "@/application/events/post/post.event";
+import { ImageAssetCleanupRequestedEvent } from "@/application/events/image/image.event";
 import { IPost, IUser } from "@/types";
 import {
   PostAuthorizationError,
@@ -29,7 +28,6 @@ import {
   UserNotFoundError,
   mapPostError,
 } from "../../../errors/post.errors";
-import { CacheKeyBuilder } from "@/utils/cache/CacheKeyBuilder";
 import { TOKENS } from "@/types/tokens";
 import { logger } from "@/utils/winston";
 
@@ -59,19 +57,11 @@ export class DeletePostCommandHandler implements ICommandHandler<
     private readonly communityMemberRepository: CommunityMemberRepository,
     @inject(TOKENS.Services.Tag) private readonly tagService: TagService,
     @inject(TOKENS.Services.Image) private readonly imageService: ImageService,
-    @inject(TOKENS.Services.Redis) private readonly redisService: RedisService,
-    @inject(TOKENS.Services.Retry) private readonly retryService: RetryService,
     @inject(TOKENS.CQRS.Handlers.EventBus) private readonly eventBus: EventBus,
   ) {}
 
   async execute(command: DeletePostCommand): Promise<DeletePostResult> {
     let postAuthorPublicId: string | undefined;
-    let imageAssetToDelete: {
-      url: string;
-      ownerPublicId: UserPublicId;
-      requesterPublicId: UserPublicId;
-    } | null = null;
-
     try {
       await this.unitOfWork.executeInTransaction(async () => {
         const post = await this.validatePostExists(command.postPublicId);
@@ -103,11 +93,15 @@ export class DeletePostCommandHandler implements ICommandHandler<
         );
 
         if (imageRemoval?.removedUrl) {
-          imageAssetToDelete = {
-            url: imageRemoval.removedUrl,
-            ownerPublicId: imageRemoval.ownerPublicId,
-            requesterPublicId: asUserPublicId(command.requesterPublicId),
-          };
+          await this.eventBus.queueTransactional(
+            new ImageAssetCleanupRequestedEvent(
+              "post-deleted",
+              undefined,
+              imageRemoval.removedUrl,
+              asUserPublicId(command.requesterPublicId),
+              imageRemoval.ownerPublicId,
+            ),
+          );
         }
 
         await this.deletePostAndComments(post);
@@ -121,17 +115,11 @@ export class DeletePostCommandHandler implements ICommandHandler<
         }
 
         await this.decrementTagUsage(post);
+        await this.queueDeleteEvent(
+          command.postPublicId,
+          postAuthorPublicId ?? command.requesterPublicId,
+        );
       });
-
-      await this.deleteImageAssetAfterCommit(imageAssetToDelete);
-      await this.invalidateCache(
-        command.requesterPublicId,
-        command.postPublicId,
-      );
-      await this.publishDeleteEvent(
-        command.postPublicId,
-        postAuthorPublicId ?? command.requesterPublicId,
-      );
 
       return { message: "Post deleted successfully" };
     } catch (error) {
@@ -250,39 +238,10 @@ export class DeletePostCommandHandler implements ICommandHandler<
         `[DeletePostHandler] Failed to delete image ${imageId} for post ${post.publicId}:`,
         error,
       );
-      return null;
+      throw error;
     }
 
     return null;
-  }
-
-  private async deleteImageAssetAfterCommit(
-    assetInfo: {
-      url: string;
-      ownerPublicId: UserPublicId;
-      requesterPublicId: UserPublicId;
-    } | null,
-  ): Promise<void> {
-    if (!assetInfo?.url) {
-      return;
-    }
-
-    try {
-      await this.retryService.execute(
-        () =>
-          this.imageService.deleteAttachmentAsset({
-            requesterPublicId: assetInfo.requesterPublicId,
-            ownerPublicId: assetInfo.ownerPublicId,
-            url: assetInfo.url,
-          }),
-        RetryPresets.externalApi(),
-      );
-    } catch (error) {
-      logger.error(
-        `[DeletePostHandler] Failed to delete image asset ${assetInfo.url}:`,
-        error,
-      );
-    }
   }
 
   private async deletePostAndComments(post: IPost): Promise<void> {
@@ -312,35 +271,11 @@ export class DeletePostCommandHandler implements ICommandHandler<
     await this.tagService.decrementUsage(tagIds);
   }
 
-  private async invalidateCache(
-    userPublicId: UserPublicId,
-    postPublicId: PostPublicId,
-  ): Promise<void> {
-    // 1. Remove from user's own feed cache
-    await this.redisService.invalidateByTags([
-      CacheKeyBuilder.getUserFeedTag(userPublicId),
-    ]);
-
-    // 2. Remove from global feed caches
-    await this.redisService.invalidateByTags([
-      CacheKeyBuilder.getTrendingFeedTag(),
-      CacheKeyBuilder.getNewFeedTag(),
-    ]);
-
-    // 3. Remove from trending ZSET (leaderboard)
-    await this.redisService.zrem("trending:posts", postPublicId);
-
-    // 4. Remove from post metadata cache
-    await this.redisService.invalidateByTags([
-      CacheKeyBuilder.getPostMetaKey(postPublicId),
-    ]);
-  }
-
-  private async publishDeleteEvent(
+  private async queueDeleteEvent(
     postPublicId: PostPublicId,
     authorPublicId: string,
   ): Promise<void> {
-    await this.eventBus.publish(
+    await this.eventBus.queueTransactional(
       new PostDeletedEvent(postPublicId, asUserPublicId(authorPublicId)),
     );
   }

--- a/backend/src/application/common/buses/event.bus.ts
+++ b/backend/src/application/common/buses/event.bus.ts
@@ -83,6 +83,15 @@ export class EventBus {
     );
   }
 
+  async queueDurable<TEvent extends IEvent>(event: TEvent): Promise<void> {
+    await this.outboxRepository.saveEvent(
+      event.constructor.name,
+      event,
+      randomUUID(),
+      getCorrelationId(),
+    );
+  }
+
   private resolveHandlerKey(handler: unknown): string {
     if (
       typeof handler === "object" &&

--- a/backend/src/application/events/image/image-asset-cleanup-requested.handler.ts
+++ b/backend/src/application/events/image/image-asset-cleanup-requested.handler.ts
@@ -1,0 +1,56 @@
+import { inject, injectable } from "tsyringe";
+import { IEventHandler } from "@/application/common/interfaces/event-handler.interface";
+import { ImageAssetCleanupRequestedEvent } from "@/application/events/image/image.event";
+import { ImageService } from "@/services/image.service";
+import { RetryPresets, RetryService } from "@/services/retry.service";
+import { Errors } from "@/utils/errors";
+import { logger } from "@/utils/winston";
+import { TOKENS } from "@/types/tokens";
+
+@injectable()
+export class ImageAssetCleanupRequestedHandler
+  implements IEventHandler<ImageAssetCleanupRequestedEvent>
+{
+  constructor(
+    @inject(TOKENS.Services.Image) private readonly imageService: ImageService,
+    @inject(TOKENS.Services.Retry) private readonly retryService: RetryService,
+  ) {}
+
+  async handle(event: ImageAssetCleanupRequestedEvent): Promise<void> {
+    logger.info("[ImageAssetCleanup] Cleaning up storage asset", {
+      reason: event.reason,
+      storagePublicId: event.storagePublicId,
+      url: event.url,
+    });
+
+    const storagePublicId = event.storagePublicId;
+    if (storagePublicId) {
+      await this.retryService.execute(
+        () => this.imageService.deleteUploadedAsset(storagePublicId),
+        RetryPresets.externalApi(),
+      );
+      return;
+    }
+
+    if (event.url && event.requesterPublicId && event.ownerPublicId) {
+      await this.retryService.execute(
+        () =>
+          this.imageService.deleteAttachmentAsset({
+            requesterPublicId: event.requesterPublicId!,
+            ownerPublicId: event.ownerPublicId!,
+            url: event.url!,
+          }),
+        RetryPresets.externalApi(),
+      );
+      return;
+    }
+
+    throw Errors.internal("Image cleanup event missing storage identifier", {
+      context: {
+        reason: event.reason,
+        hasStoragePublicId: Boolean(event.storagePublicId),
+        hasUrl: Boolean(event.url),
+      },
+    });
+  }
+}

--- a/backend/src/application/events/image/image.event.ts
+++ b/backend/src/application/events/image/image.event.ts
@@ -28,3 +28,20 @@ export class ImageDeletedEvent implements IEvent {
     public readonly uploaderPublicId: UserPublicId,
   ) {}
 }
+
+/**
+ * Durable compensation request for storage assets that cannot be covered by
+ * the MongoDB transaction boundary.
+ */
+export class ImageAssetCleanupRequestedEvent implements IEvent {
+  readonly type = "ImageAssetCleanupRequestedEvent";
+  readonly timestamp: Date = new Date();
+
+  constructor(
+    public readonly reason: string,
+    public readonly storagePublicId?: string,
+    public readonly url?: string,
+    public readonly requesterPublicId?: UserPublicId,
+    public readonly ownerPublicId?: UserPublicId,
+  ) {}
+}

--- a/backend/src/application/events/post/post-deleted.handler.ts
+++ b/backend/src/application/events/post/post-deleted.handler.ts
@@ -32,6 +32,8 @@ export class PostDeleteHandler implements IEventHandler<PostDeletedEvent> {
         CacheKeyBuilder.getUserForYouFeedTag(event.authorPublicId),
       );
       tagsToInvalidate.push(`user_post_count:${event.authorPublicId}`);
+      tagsToInvalidate.push(CacheKeyBuilder.getNewFeedTag());
+      tagsToInvalidate.push(CacheKeyBuilder.getPostMetaKey(event.postId));
 
       const followers = await this.getFollowersOfUser(event.authorPublicId);
       if (followers.length > 0) {
@@ -56,6 +58,7 @@ export class PostDeleteHandler implements IEventHandler<PostDeletedEvent> {
       });
 
       await this.redis.deletePatterns(patterns);
+      await this.redis.zrem("trending:posts", event.postId);
 
       await this.redis.publish(
         "feed_updates",

--- a/backend/src/di/handlers.di.ts
+++ b/backend/src/di/handlers.di.ts
@@ -27,12 +27,14 @@ import {
   PostDeletedEvent,
   PostUploadedEvent,
 } from "@/application/events/post/post.event";
+import { ImageAssetCleanupRequestedEvent } from "@/application/events/image/image.event";
 import { LikeActionCommand } from "@/application/commands/users/likeAction/likeAction.command";
 import { LikeActionCommandHandler } from "@/application/commands/users/likeAction/likeAction.handler";
 import { LikeActionByPublicIdCommand } from "@/application/commands/users/likeActionByPublicId/likeActionByPublicId.command";
 import { LikeActionByPublicIdCommandHandler } from "@/application/commands/users/likeActionByPublicId/likeActionByPublicId.handler";
 import { PostUploadHandler } from "@/application/events/post/post-uploaded.handler";
 import { PostDeleteHandler } from "@/application/events/post/post-deleted.handler";
+import { ImageAssetCleanupRequestedHandler } from "@/application/events/image/image-asset-cleanup-requested.handler";
 import {
   UserAvatarChangedEvent,
   UserUsernameChangedEvent,
@@ -350,6 +352,9 @@ export function registerCQRS(): void {
   });
   container.register(TOKENS.CQRS.Handlers.PostDelete, {
     useClass: PostDeleteHandler,
+  });
+  container.register(TOKENS.CQRS.Handlers.ImageAssetCleanupRequested, {
+    useClass: ImageAssetCleanupRequestedHandler,
   });
   container.register(TOKENS.CQRS.Handlers.UserAvatarChanged, {
     useClass: UserAvatarChangedHandler,
@@ -772,6 +777,12 @@ export function initCQRS(): void {
   eventBus.subscribe(
     PostDeletedEvent,
     container.resolve<PostDeleteHandler>(TOKENS.CQRS.Handlers.PostDelete),
+  );
+  eventBus.subscribe(
+    ImageAssetCleanupRequestedEvent,
+    container.resolve<ImageAssetCleanupRequestedHandler>(
+      TOKENS.CQRS.Handlers.ImageAssetCleanupRequested,
+    ),
   );
   eventBus.subscribe(
     UserAvatarChangedEvent,

--- a/backend/src/models/post.model.ts
+++ b/backend/src/models/post.model.ts
@@ -72,6 +72,17 @@ const postSchema = new Schema<IPost>(
 			default: "original",
 			required: true,
 		},
+		status: {
+			type: String,
+			enum: ["pending", "active", "failed"],
+			default: "active",
+			required: true,
+			index: true,
+		},
+		failureReason: {
+			type: String,
+			trim: true,
+		},
 		repostOf: {
 			type: Schema.Types.ObjectId,
 			ref: "Post",
@@ -127,6 +138,7 @@ postSchema.index({ body: "text" }); // text search on body
 postSchema.index({ slug: 1 }, { unique: true, sparse: true }); // fast lookup by slug
 postSchema.index({ commentsCount: -1, likesCount: -1 }); // engagement ranking
 postSchema.index({ type: 1, createdAt: -1 }); // filter by post type (original vs repost)
+postSchema.index({ status: 1, createdAt: -1 }); // hide pending/failed uploads from feeds
 postSchema.index({ createdAt: -1 }, { background: true }); // recent posts
 postSchema.index({ createdAt: -1, _id: -1 }, { background: true }); // cursor-based feed sort
 postSchema.index({ createdAt: -1, tags: 1 }, { background: true }); // trending tags window with tag filter

--- a/backend/src/repositories/interfaces/IPostWriteRepository.ts
+++ b/backend/src/repositories/interfaces/IPostWriteRepository.ts
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import { IPost } from "@/types";
+import { IPost, PostStatus } from "@/types";
 import { MongoId } from "@/types/branded";
 
 /**
@@ -17,6 +17,19 @@ export interface IPostWriteRepository {
   updateCommentCount(postId: MongoId, increment: number): Promise<void>;
   updateLikeCount(postId: MongoId, increment: number): Promise<void>;
   updateRepostCount(postId: MongoId, increment: number): Promise<void>;
+  activatePendingPost(
+    postId: MongoId,
+    updates: {
+      image: mongoose.Types.ObjectId | null;
+      tags: mongoose.Types.ObjectId[];
+      slug: string;
+    },
+  ): Promise<IPost | null>;
+  updatePostStatus(
+    postId: MongoId,
+    status: PostStatus,
+    failureReason?: string,
+  ): Promise<void>;
 
   // bulk operations
   deleteManyByUserId(userId: MongoId): Promise<number>;

--- a/backend/src/repositories/post-pipeline.helpers.ts
+++ b/backend/src/repositories/post-pipeline.helpers.ts
@@ -3,8 +3,21 @@
  * Used by PostReadRepository and FeedReadDao to avoid duplication.
  */
 
-import mongoose, { PipelineStage } from "mongoose";
+import mongoose, { FilterQuery, PipelineStage } from "mongoose";
 import { Errors } from "@/utils/errors";
+
+export const ACTIVE_POST_FILTER: FilterQuery<any> = {
+  $or: [{ status: "active" }, { status: { $exists: false } }],
+};
+
+export function withActivePostFilter<T extends Record<string, unknown>>(
+  filter: T = {} as T,
+): FilterQuery<any> {
+  if (Object.keys(filter).length === 0) {
+    return ACTIVE_POST_FILTER;
+  }
+  return { $and: [ACTIVE_POST_FILTER, filter] };
+}
 
 export function getStandardLookups(): PipelineStage.FacetPipelineStage[] {
   return [
@@ -39,7 +52,12 @@ export function getStandardLookups(): PipelineStage.FacetPipelineStage[] {
         from: "posts",
         let: { repostId: "$repostOf" },
         pipeline: [
-          { $match: { $expr: { $eq: ["$_id", "$$repostId"] } } },
+          {
+            $match: {
+              $expr: { $eq: ["$_id", "$$repostId"] },
+              ...ACTIVE_POST_FILTER,
+            },
+          },
           {
             $lookup: {
               from: "images",

--- a/backend/src/repositories/post.repository.ts
+++ b/backend/src/repositories/post.repository.ts
@@ -11,6 +11,10 @@ import {
   UserPublicId,
   asMongoId,
 } from "@/types/branded";
+import {
+  ACTIVE_POST_FILTER,
+  withActivePostFilter,
+} from "@/repositories/post-pipeline.helpers";
 
 type CountFacetResult = {
   count: number;
@@ -39,7 +43,7 @@ export class PostRepository extends BaseRepository<IPost> {
       const searchString = terms.join(" ");
 
       const pipeline: PipelineStage[] = [
-        { $match: { $text: { $search: searchString } } },
+        { $match: withActivePostFilter({ $text: { $search: searchString } }) },
         { $addFields: { score: { $meta: "textScore" } } },
         // Sort by text relevance score before trimming the result window
         { $sort: { score: { $meta: "textScore" } } },
@@ -63,7 +67,7 @@ export class PostRepository extends BaseRepository<IPost> {
     publicId: PostPublicId,
   ): Promise<MongoId | null> {
     const doc = await this.model
-      .findOne({ publicId })
+      .findOne(withActivePostFilter({ publicId }))
       .select("_id")
       .lean()
       .exec();
@@ -73,7 +77,7 @@ export class PostRepository extends BaseRepository<IPost> {
   async findOneByPublicId(publicId: PostPublicId): Promise<IPost | null> {
     try {
       const session = this.getSession();
-      const query = this.model.findOne({ publicId });
+      const query = this.model.findOne(withActivePostFilter({ publicId }));
       if (session) query.session(session);
       return await query.exec();
     } catch (error: unknown) {
@@ -102,7 +106,7 @@ export class PostRepository extends BaseRepository<IPost> {
   ): Promise<IPost[]> {
     const skip = (page - 1) * limit;
     return this.model
-      .find({ communityId })
+      .find(withActivePostFilter({ communityId }))
       .sort({ createdAt: -1, _id: -1 })
       .skip(skip)
       .limit(limit)
@@ -111,7 +115,7 @@ export class PostRepository extends BaseRepository<IPost> {
   }
 
   async countByCommunityId(communityId: string): Promise<number> {
-    return this.model.countDocuments({ communityId }).exec();
+    return this.model.countDocuments(withActivePostFilter({ communityId })).exec();
   }
 
   async incrementViewCount(postId: mongoose.Types.ObjectId): Promise<void> {
@@ -157,7 +161,7 @@ export class PostRepository extends BaseRepository<IPost> {
     try {
       const session = this.getSession();
       const query = this.model
-        .findById(id)
+        .findOne(withActivePostFilter({ _id: id }))
         .populate("tags", "tag")
         .populate({ path: "image", select: "_id url publicId slug createdAt" });
 
@@ -176,7 +180,7 @@ export class PostRepository extends BaseRepository<IPost> {
       const objectIds = ids.map((id) => this.normalizeObjectId(id, "id"));
 
       const pipeline: PipelineStage[] = [
-        { $match: { _id: { $in: objectIds } } },
+        { $match: withActivePostFilter({ _id: { $in: objectIds } }) },
         ...this.getStandardLookups(),
         this.getStandardProjection(),
       ];
@@ -206,7 +210,7 @@ export class PostRepository extends BaseRepository<IPost> {
       }
 
       const pipeline: PipelineStage[] = [
-        { $match: { publicId: { $in: uniqueIds } } },
+        { $match: withActivePostFilter({ publicId: { $in: uniqueIds } }) },
         ...this.getStandardLookups(),
         this.getStandardProjection(),
       ];
@@ -224,7 +228,7 @@ export class PostRepository extends BaseRepository<IPost> {
     try {
       const session = this.getSession();
       const query = this.model
-        .findOne({ publicId })
+        .findOne(withActivePostFilter({ publicId }))
         .populate("tags", "tag")
         .populate({ path: "image", select: "_id url publicId slug createdAt" })
         .populate({ path: "communityId", select: "publicId name slug avatar" })
@@ -254,7 +258,7 @@ export class PostRepository extends BaseRepository<IPost> {
     try {
       const session = this.getSession();
       const query = this.model
-        .findOne({ slug })
+        .findOne(withActivePostFilter({ slug }))
         .populate("tags", "tag")
         .populate({
           path: "image",
@@ -294,7 +298,7 @@ export class PostRepository extends BaseRepository<IPost> {
       const userId = this.normalizeObjectId(userDoc._id, "user._id");
 
       const pipeline: PipelineStage[] = [
-        { $match: { user: userId } },
+        { $match: withActivePostFilter({ user: userId }) },
         { $sort: sort },
         {
           $facet: {
@@ -344,6 +348,7 @@ export class PostRepository extends BaseRepository<IPost> {
       const sort = this.buildSort(sortBy, sortOrder);
 
       const pipeline: PipelineStage[] = [
+        { $match: ACTIVE_POST_FILTER },
         { $sort: sort },
         {
           $facet: {
@@ -399,14 +404,14 @@ export class PostRepository extends BaseRepository<IPost> {
 
       const [data, total] = await Promise.all([
         this.model
-          .find({ tags: { $in: tagIds } })
+          .find(withActivePostFilter({ tags: { $in: tagIds } }))
           .populate("tags", "tag")
           .populate({ path: "image", select: "url publicId slug -_id" })
           .sort(sort)
           .skip(skip)
           .limit(limit)
           .exec(),
-        this.model.countDocuments({ tags: { $in: tagIds } }),
+        this.model.countDocuments(withActivePostFilter({ tags: { $in: tagIds } })),
       ]);
 
       return {
@@ -585,7 +590,12 @@ export class PostRepository extends BaseRepository<IPost> {
           from: "posts",
           let: { repostId: "$repostOf" },
           pipeline: [
-            { $match: { $expr: { $eq: ["$_id", "$$repostId"] } } },
+            {
+              $match: {
+                $expr: { $eq: ["$_id", "$$repostId"] },
+                ...ACTIVE_POST_FILTER,
+              },
+            },
 
             {
               $lookup: {

--- a/backend/src/repositories/read/FeedReadDao.ts
+++ b/backend/src/repositories/read/FeedReadDao.ts
@@ -14,6 +14,10 @@ import {
 import { decodeCursor, encodeCursor } from "@/utils/cursorCodec";
 import { TOKENS } from "@/types/tokens";
 import { Errors } from "@/utils/errors";
+import {
+  ACTIVE_POST_FILTER,
+  withActivePostFilter,
+} from "@/repositories/post-pipeline.helpers";
 
 type ProjectedFeedPost = FeedPost & {
   _id?: mongoose.Types.ObjectId;
@@ -124,7 +128,9 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
       };
 
       if (phase === "personalized" && orConditions.length > 0) {
-        const pipeline: PipelineStage[] = [{ $match: { $or: orConditions } }];
+        const pipeline: PipelineStage[] = [
+          { $match: withActivePostFilter({ $or: orConditions }) },
+        ];
 
         if (Object.keys(cursorFilter).length > 0) {
           pipeline.push({ $match: cursorFilter });
@@ -163,6 +169,7 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
         // There is a slight risk of overlap if a personalized post IS ALSO a recent backfill post,
         // but $nin is too expensive. We can just distinct in memory or accept slight overlap.
         const backfillPipeline: PipelineStage[] = [
+          { $match: ACTIVE_POST_FILTER },
           { $sort: { createdAt: -1, _id: -1 } },
           // If we ALREADY fetched some personalized posts on this CURRENT page, we should theoretically offset the backfill.
           // However, to keep it simple, we just start backfill from scratch and cursor tracking will remember where we are based on the Last Backfill Post.
@@ -191,7 +198,9 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
           }
         }
       } else if (phase === "backfill") {
-        const backfillPipeline: PipelineStage[] = [];
+        const backfillPipeline: PipelineStage[] = [
+          { $match: ACTIVE_POST_FILTER },
+        ];
         if (Object.keys(cursorFilter).length > 0) {
           backfillPipeline.push({ $match: cursorFilter });
         }
@@ -270,7 +279,7 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
       );
 
       const pipeline: PipelineStage[] = [
-        { $match: { createdAt: { $gte: sinceDate } } },
+        { $match: withActivePostFilter({ createdAt: { $gte: sinceDate } }) },
         // compute ranking scores before $lookup to sort/paginate early
         {
           $addFields: {
@@ -326,7 +335,9 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
       ];
       const [results, total] = await Promise.all([
         this.model.aggregate(pipeline).exec(),
-        this.model.countDocuments({ createdAt: { $gte: sinceDate } }),
+        this.model.countDocuments(
+          withActivePostFilter({ createdAt: { $gte: sinceDate } }),
+        ),
       ]);
 
       console.info(`Ranked feed generated with ${results.length} results`);
@@ -381,10 +392,10 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
 
       const pipeline: PipelineStage[] = [
         {
-          $match: {
+          $match: withActivePostFilter({
             createdAt: { $gte: sinceDate },
             likesCount: { $gte: minLikes },
-          },
+          }),
         },
         // compute trend scores before $lookup to sort/paginate early
         {
@@ -445,8 +456,10 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
       const [results, total] = await Promise.all([
         this.model.aggregate(pipeline).exec(),
         this.model.countDocuments({
-          createdAt: { $gte: sinceDate },
-          likesCount: { $gte: minLikes },
+          ...withActivePostFilter({
+            createdAt: { $gte: sinceDate },
+            likesCount: { $gte: minLikes },
+          }),
         }),
       ]);
 
@@ -483,6 +496,7 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
   ): Promise<PaginationResult<FeedPost>> {
     try {
       const pipeline: PipelineStage[] = [
+        { $match: ACTIVE_POST_FILTER },
         { $sort: { createdAt: -1, _id: -1 } },
         { $skip: skip },
         { $limit: limit },
@@ -497,7 +511,7 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
 
       const [results, total] = await Promise.all([
         this.model.aggregate(pipeline).exec(),
-        this.model.countDocuments({}),
+        this.model.countDocuments(ACTIVE_POST_FILTER),
       ]);
       const totalPages = Math.ceil(total / limit);
       const currentPage = Math.floor(skip / limit) + 1;
@@ -523,10 +537,10 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
 
       const pipeline: PipelineStage[] = [
         {
-          $match: {
+          $match: withActivePostFilter({
             createdAt: { $gte: timeThreshold },
             tags: { $exists: true, $not: { $size: 0 } },
-          },
+          }),
         },
         {
           $project: {
@@ -661,6 +675,7 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
 
       // fetch one extra to determine if there are more results
       const pipeline: PipelineStage[] = [
+        { $match: ACTIVE_POST_FILTER },
         ...(Object.keys(cursorFilter).length > 0
           ? [{ $match: cursorFilter }]
           : []),
@@ -795,10 +810,10 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
 
       const pipeline: PipelineStage[] = [
         {
-          $match: {
+          $match: withActivePostFilter({
             createdAt: { $gte: sinceDate },
             likesCount: { $gte: minLikes },
-          },
+          }),
         },
         // compute trend scores before cursor filtering
         {
@@ -977,7 +992,7 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
       const feedProjection = this.getStandardProjectionFields();
 
       const pipeline: PipelineStage[] = [
-        { $match: { createdAt: { $gte: sinceDate } } },
+        { $match: withActivePostFilter({ createdAt: { $gte: sinceDate } }) },
         // compute ranking scores before cursor filtering
         {
           $addFields: {
@@ -1105,6 +1120,7 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
     try {
       const lookups = this.getStandardLookups();
       const pipeline: PipelineStage[] = [
+        { $match: ACTIVE_POST_FILTER },
         { $sort: { createdAt: -1, _id: -1 } },
         {
           $facet: {
@@ -1187,10 +1203,10 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
 
       const pipeline: PipelineStage[] = [
         {
-          $match: {
+          $match: withActivePostFilter({
             createdAt: { $gte: sinceDate },
             likesCount: { $gte: minLikes },
-          },
+          }),
         },
         // compute trend scores early
         {
@@ -1314,7 +1330,12 @@ export class FeedReadDao extends BaseRepository<IPost> implements IFeedReadDao {
           from: "posts",
           let: { repostId: "$repostOf" },
           pipeline: [
-            { $match: { $expr: { $eq: ["$_id", "$$repostId"] } } },
+            {
+              $match: {
+                $expr: { $eq: ["$_id", "$$repostId"] },
+                ...ACTIVE_POST_FILTER,
+              },
+            },
 
             {
               $lookup: {

--- a/backend/src/repositories/read/PostReadRepository.ts
+++ b/backend/src/repositories/read/PostReadRepository.ts
@@ -14,10 +14,12 @@ import { Errors } from "@/utils/errors";
 import {
   buildFacetPipeline,
   buildSort,
+  ACTIVE_POST_FILTER,
   getStandardLookups,
   getStandardProjection,
   getStandardProjectionFields,
   normalizeObjectId,
+  withActivePostFilter,
 } from "@/repositories/post-pipeline.helpers";
 
 type CountFacetResult = { count: number };
@@ -39,7 +41,7 @@ export class PostReadRepository
       const searchString = terms.join(" ");
 
       const pipeline: PipelineStage[] = [
-        { $match: { $text: { $search: searchString } } },
+        { $match: withActivePostFilter({ $text: { $search: searchString } }) },
         { $addFields: { score: { $meta: "textScore" } } },
         { $sort: { score: { $meta: "textScore" } } },
         { $limit: limit },
@@ -59,7 +61,7 @@ export class PostReadRepository
     publicId: PostPublicId,
   ): Promise<MongoId | null> {
     const doc = await this.model
-      .findOne({ publicId })
+      .findOne(withActivePostFilter({ publicId }))
       .select("_id")
       .lean()
       .exec();
@@ -69,7 +71,7 @@ export class PostReadRepository
   async findOneByPublicId(publicId: PostPublicId): Promise<IPost | null> {
     try {
       const session = this.getSession();
-      const query = this.model.findOne({ publicId });
+      const query = this.model.findOne(withActivePostFilter({ publicId }));
       if (session) query.session(session);
       return await query.exec();
     } catch (error: unknown) {
@@ -111,7 +113,7 @@ export class PostReadRepository
     try {
       const session = this.getSession();
       const query = this.model
-        .findOne({ publicId })
+        .findOne(withActivePostFilter({ publicId }))
         .select(
           "publicId user author body slug type repostOf repostCount image tags likesCount commentsCount viewsCount createdAt updatedAt communityId",
         )
@@ -143,7 +145,7 @@ export class PostReadRepository
     try {
       const session = this.getSession();
       const query = this.model
-        .findOne({ slug })
+        .findOne(withActivePostFilter({ slug }))
         .populate("tags", "tag")
         .populate({
           path: "image",
@@ -165,7 +167,7 @@ export class PostReadRepository
   ): Promise<IPost[]> {
     const skip = (page - 1) * limit;
     return this.model
-      .find({ communityId })
+      .find(withActivePostFilter({ communityId }))
       .sort({ createdAt: -1, _id: -1 })
       .skip(skip)
       .limit(limit)
@@ -180,7 +182,7 @@ export class PostReadRepository
     try {
       const objectIds = ids.map((id) => normalizeObjectId(id, "id"));
       const pipeline: PipelineStage[] = [
-        { $match: { _id: { $in: objectIds } } },
+        { $match: withActivePostFilter({ _id: { $in: objectIds } }) },
         ...getStandardLookups(),
         getStandardProjection(),
       ];
@@ -201,7 +203,7 @@ export class PostReadRepository
       );
       if (uniqueIds.length === 0) return [];
       const pipeline: PipelineStage[] = [
-        { $match: { publicId: { $in: uniqueIds } } },
+        { $match: withActivePostFilter({ publicId: { $in: uniqueIds } }) },
         ...getStandardLookups(),
         getStandardProjection(),
       ];
@@ -235,7 +237,7 @@ export class PostReadRepository
       const userId = normalizeObjectId(userDoc._id, "user._id");
 
       const pipeline: PipelineStage[] = [
-        { $match: { user: userId } },
+        { $match: withActivePostFilter({ user: userId }) },
         { $sort: sort },
         {
           $facet: {
@@ -278,6 +280,7 @@ export class PostReadRepository
       const sort = buildSort(sortBy, sortOrder);
 
       const pipeline: PipelineStage[] = [
+        { $match: ACTIVE_POST_FILTER },
         { $sort: sort },
         {
           $facet: {
@@ -326,14 +329,14 @@ export class PostReadRepository
 
       const [data, total] = await Promise.all([
         this.model
-          .find({ tags: { $in: tagIds } })
+          .find(withActivePostFilter({ tags: { $in: tagIds } }))
           .populate("tags", "tag")
           .populate({ path: "image", select: "url publicId slug -_id" })
           .sort(sort)
           .skip(skip)
           .limit(limit)
           .exec(),
-        this.model.countDocuments({ tags: { $in: tagIds } }),
+        this.model.countDocuments(withActivePostFilter({ tags: { $in: tagIds } })),
       ]);
 
       return { data, total, page, limit, totalPages: Math.ceil(total / limit) };

--- a/backend/src/repositories/write/PostWriteRepository.ts
+++ b/backend/src/repositories/write/PostWriteRepository.ts
@@ -1,6 +1,6 @@
 import mongoose, { Model } from "mongoose";
 import { inject, injectable } from "tsyringe";
-import { IPost } from "@/types";
+import { IPost, PostStatus } from "@/types";
 import type { IPostWriteRepository } from "../interfaces/IPostWriteRepository";
 import { BaseRepository } from "../base.repository";
 import { TOKENS } from "@/types/tokens";
@@ -40,6 +40,57 @@ export class PostWriteRepository
         { _id: postId },
         { $inc: { repostCount: increment } },
       );
+      if (session) query.session(session);
+      await query.exec();
+    } catch (error: unknown) {
+      throw Errors.database(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  async activatePendingPost(
+    postId: MongoId,
+    updates: {
+      image: mongoose.Types.ObjectId | null;
+      tags: mongoose.Types.ObjectId[];
+      slug: string;
+    },
+  ): Promise<IPost | null> {
+    try {
+      const session = this.getSession();
+      const query = this.model.findOneAndUpdate(
+        { _id: postId, status: "pending" },
+        {
+          $set: {
+            ...updates,
+            status: "active",
+          },
+          $unset: { failureReason: 1 },
+        },
+        { new: true },
+      );
+      if (session) query.session(session);
+      return await query.exec();
+    } catch (error: unknown) {
+      throw Errors.database(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  async updatePostStatus(
+    postId: MongoId,
+    status: PostStatus,
+    failureReason?: string,
+  ): Promise<void> {
+    try {
+      const session = this.getSession();
+      const update =
+        failureReason === undefined
+          ? { $set: { status }, $unset: { failureReason: 1 } }
+          : { $set: { status, failureReason } };
+      const query = this.model.updateOne({ _id: postId }, update);
       if (session) query.session(session);
       await query.exec();
     } catch (error: unknown) {

--- a/backend/src/services/image.service.ts
+++ b/backend/src/services/image.service.ts
@@ -111,10 +111,14 @@ export class ImageService {
   async rollbackUpload(publicId: string | null | undefined): Promise<void> {
     if (!publicId) return;
     try {
-      await this.imageStorageService.deleteImage(publicId);
+      await this.deleteUploadedAsset(publicId);
     } catch (error) {
       logger.error("Failed to rollback image upload", { error });
     }
+  }
+
+  async deleteUploadedAsset(publicId: string): Promise<void> {
+    await this.imageStorageService.deleteImage(publicId);
   }
 
   async removePostAttachment(

--- a/backend/src/types/customPosts/posts.types.ts
+++ b/backend/src/types/customPosts/posts.types.ts
@@ -22,6 +22,8 @@ export interface IPost extends Document {
   body?: string;
   slug?: string;
   type: "original" | "repost";
+  status: PostStatus;
+  failureReason?: string;
   repostOf?: mongoose.Types.ObjectId | null;
   repostCount: number;
   image?: mongoose.Types.ObjectId | null;
@@ -37,6 +39,8 @@ export interface IPost extends Document {
     user?: Pick<IUser, "isAdmin" | "isBanned" | "publicId"> | null,
   ): boolean;
 }
+
+export type PostStatus = "pending" | "active" | "failed";
 
 export interface CreatePostAttachmentInput {
   filePath: string;

--- a/backend/src/types/tokens.ts
+++ b/backend/src/types/tokens.ts
@@ -83,6 +83,7 @@ export const TOKENS = {
     Handlers: {
       EventBus: "EventBus",
       FeedInteraction: "FeedInteractionHandler",
+      ImageAssetCleanupRequested: "ImageAssetCleanupRequestedHandler",
       MessageAttachmentsDeleted: "MessageAttachmentsDeletedHandler",
       MessageSent: "MessageSentHandler",
       MessageStatusUpdatedEvent: "MessageStatusUpdatedEventHandler",

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -18,7 +18,7 @@ services:
 
   # --- APP LAYER ---
   backend:
-    image: ghcr.io/danzin/photoapp-backend:latest
+    image: ghcr.io/sunsetstack/ascendance-backend:latest
     container_name: backend
     restart: always
     environment: &backend-environment
@@ -46,7 +46,7 @@ services:
       retries: 5
 
   frontend:
-    image: ghcr.io/danzin/photoapp-frontend:latest
+    image: ghcr.io/sunsetstack/ascendance-frontend:latest
     container_name: frontend
     restart: always
     depends_on:
@@ -96,7 +96,7 @@ services:
 
   # Dedicated worker container
   backend-worker:
-    image: ghcr.io/danzin/photoapp-backend:latest
+    image: ghcr.io/sunsetstack/ascendance-backend:latest
     container_name: backend-worker
     restart: always
     environment:


### PR DESCRIPTION
 - PENDING status on posts + activation after upload for visibility and outbox compensation cleanup for external storage cleanup after failure
 - When a storage asset may need cleanup, we create an `ImageAssetCleanupRequestedEvent`
 - That event is written to the outbox either:
   - transactionally with `queueTransactional(...)` if we are inside the DB transaction
   - durably with `queueDurable(...)` if we're outside a transaction but still need retryable cleanup
 - `OutboxWorker` polls the outbox table/collection, claims pending events, and calls the registered handler
 - The cleanup handler tries to delete the asset. If deletion fails it throws and the outbox record is marked failed for retry later