### PR TITLE
tidying up the frontend, one piece at a time

### DIFF
--- a/backend/src/__tests__/services/dto.service.test.ts
+++ b/backend/src/__tests__/services/dto.service.test.ts
@@ -60,4 +60,70 @@ describe("DTOService.toPostDTO", () => {
 			avatar: "snap.png",
 		});
 	});
+
+	it("preserves repost content for aggregated feed posts", () => {
+		const dto = service.toPostDTO({
+			...basePost,
+			publicId: "repost-1",
+			type: "repost",
+			repostCount: 2,
+			userPublicId: "user-1",
+			likes: 1,
+			user: {
+				publicId: "user-1",
+				handle: "sharer",
+				username: "Sharer",
+				avatar: "sharer.png",
+			},
+			repostOf: {
+				publicId: "original-1",
+				body: "Original post",
+				slug: "original-post",
+				likes: 4,
+				repostCount: 3,
+				commentsCount: 2,
+				user: {
+					publicId: "user-2",
+					handle: "author",
+					username: "Author",
+					avatar: "author.png",
+				},
+				image: null,
+			},
+		} as any);
+
+		expect(dto.type).to.equal("repost");
+		expect(dto.repostCount).to.equal(2);
+		expect(dto.repostOf).to.deep.include({
+			publicId: "original-1",
+			body: "Original post",
+			likes: 4,
+			repostCount: 3,
+			commentsCount: 2,
+		});
+		expect(dto.repostOf?.user).to.deep.equal({
+			publicId: "user-2",
+			handle: "author",
+			username: "Author",
+			avatar: "author.png",
+		});
+	});
+
+	it("drops empty aggregated community placeholders", () => {
+		const dto = service.toPostDTO({
+			...basePost,
+			publicId: "post-without-community",
+			userPublicId: "user-1",
+			likes: 0,
+			user: {
+				publicId: "user-1",
+				handle: "author",
+				username: "Author",
+				avatar: "author.png",
+			},
+			community: {},
+		} as any);
+
+		expect(dto.community).to.equal(null);
+	});
 });

--- a/backend/src/application/queries/feed/feed-post-normalizer.ts
+++ b/backend/src/application/queries/feed/feed-post-normalizer.ts
@@ -67,7 +67,7 @@ function getUserSnapshot(post: Record<string, unknown>): UserSnapshot {
   return author && typeof author === "object" ? (author as UserSnapshot) : {};
 }
 
-function normalizeRepostOf(repostOf: unknown): Partial<FeedPost> | undefined {
+function normalizeRepostOf(repostOf: unknown): FeedPost["repostOf"] {
   if (!repostOf || typeof repostOf !== "object") {
     return undefined;
   }
@@ -79,10 +79,9 @@ function normalizeRepostOf(repostOf: unknown): Partial<FeedPost> | undefined {
     publicId: repost.publicId as string,
     body: (repost.body as string) ?? "",
     slug: (repost.slug as string) ?? "",
-    createdAt: repost.createdAt as Date,
     likes: ((repost.likesCount ?? repost.likes) as number) ?? 0,
+    repostCount: (repost.repostCount as number) ?? 0,
     commentsCount: (repost.commentsCount as number) ?? 0,
-    tags: normalizeTags(repost.tags),
     user: {
       publicId: originalUser.publicId as string,
       handle: originalUser.handle ?? "",
@@ -96,11 +95,16 @@ function normalizeRepostOf(repostOf: unknown): Partial<FeedPost> | undefined {
 export function normalizeFeedPost(post: FeedPostSource): FeedPost {
   const plainPost = toPlainRecord(post);
   const user = getUserSnapshot(plainPost);
+  const repostOf = normalizeRepostOf(plainPost.repostOf);
 
   return {
     publicId: plainPost.publicId as string,
     body: (plainPost.body as string) ?? "",
     slug: (plainPost.slug as string) ?? "",
+    type:
+      plainPost.type === "repost" || repostOf ? "repost" : "original",
+    repostCount: (plainPost.repostCount as number) ?? 0,
+    repostOf,
     createdAt: plainPost.createdAt as Date,
     likes: ((plainPost.likesCount ?? plainPost.likes) as number) ?? 0,
     commentsCount: (plainPost.commentsCount as number) ?? 0,
@@ -115,11 +119,10 @@ export function normalizeFeedPost(post: FeedPostSource): FeedPost {
     },
     image: normalizeImage(plainPost.image),
     community: (plainPost.community as FeedPost["community"]) ?? undefined,
-    repostOf: normalizeRepostOf(plainPost.repostOf),
     rankScore: plainPost.rankScore as number | undefined,
     trendScore: plainPost.trendScore as number | undefined,
     isPersonalized: plainPost.isPersonalized as boolean | undefined,
-  } as FeedPost;
+  };
 }
 
 export function normalizeFeedPosts(posts: FeedPostSource[]): FeedPost[] {

--- a/backend/src/repositories/post-pipeline.helpers.ts
+++ b/backend/src/repositories/post-pipeline.helpers.ts
@@ -109,18 +109,22 @@ export function getStandardProjectionFields(): Record<string, unknown> {
     },
     image: {
       $cond: {
-        if: { $ne: ["$imageDoc", null] },
+        if: {
+          $ne: [{ $ifNull: ["$imageDoc.publicId", null] }, null],
+        },
         then: {
           publicId: "$imageDoc.publicId",
           url: "$imageDoc.url",
           slug: "$imageDoc.slug",
         },
-        else: {},
+        else: null,
       },
     },
     repostOf: {
       $cond: {
-        if: { $ne: ["$repostDoc", null] },
+        if: {
+          $ne: [{ $ifNull: ["$repostDoc.publicId", null] }, null],
+        },
         then: {
           publicId: "$repostDoc.publicId",
           body: "$repostDoc.body",
@@ -150,7 +154,9 @@ export function getStandardProjectionFields(): Record<string, unknown> {
     },
     community: {
       $cond: {
-        if: { $ne: ["$communityDoc", null] },
+        if: {
+          $ne: [{ $ifNull: ["$communityDoc.publicId", null] }, null],
+        },
         then: {
           publicId: "$communityDoc.publicId",
           name: "$communityDoc.name",

--- a/backend/src/services/dto/post.mapper.ts
+++ b/backend/src/services/dto/post.mapper.ts
@@ -20,6 +20,7 @@ function isFeedPost(post: IPost | FeedPost): post is FeedPost {
 
 function feedPostToDTO(post: FeedPost): PostDTO {
   const tags = post.tags.map((tag) => tag.tag).filter(Boolean);
+  const repostOf = buildFeedPostRepostOf(post.repostOf);
 
   const image =
     post.image?.url && post.image?.publicId
@@ -38,9 +39,9 @@ function feedPostToDTO(post: FeedPost): PostDTO {
     publicId: asPostPublicId(post.publicId),
     body: post.body,
     slug: post.slug,
-    type: "original",
-    repostCount: 0,
-    repostOf: undefined,
+    type: post.type === "repost" || repostOf ? "repost" : "original",
+    repostCount: post.repostCount ?? 0,
+    repostOf,
     image,
     url,
     imagePublicId,
@@ -127,12 +128,42 @@ function iPostToDTO(post: IPost): PostDTO {
 function buildFeedPostCommunity(
   community: FeedPost["community"],
 ): PostDTO["community"] {
-  if (!community) return null;
+  if (!community?.publicId || !community.name || !community.slug) return null;
   return {
     publicId: asCommunityPublicId(community.publicId),
     name: community.name,
     slug: community.slug,
     avatar: community.avatar,
+  };
+}
+
+function buildFeedPostRepostOf(
+  repost: FeedPost["repostOf"],
+): PostDTO["repostOf"] {
+  if (!repost?.publicId) return undefined;
+
+  const image =
+    repost.image?.url && repost.image?.publicId
+      ? {
+          url: repost.image.url,
+          publicId: asImagePublicId(repost.image.publicId),
+        }
+      : null;
+
+  return {
+    publicId: asPostPublicId(repost.publicId),
+    user: {
+      publicId: asUserPublicId(repost.user?.publicId ?? ""),
+      handle: repost.user?.handle ?? "",
+      username: repost.user?.username ?? "",
+      avatar: repost.user?.avatar ?? "",
+    },
+    body: repost.body,
+    slug: repost.slug,
+    image,
+    likes: repost.likes ?? repost.likesCount ?? 0,
+    repostCount: repost.repostCount ?? 0,
+    commentsCount: repost.commentsCount ?? 0,
   };
 }
 

--- a/backend/src/types/customFeeds/feed.types.ts
+++ b/backend/src/types/customFeeds/feed.types.ts
@@ -1,8 +1,33 @@
 import { UserPublicId } from "@/types/branded";
+
+export interface FeedPostRepost {
+  publicId: string;
+  body?: string;
+  slug?: string;
+  likes?: number;
+  likesCount?: number;
+  repostCount?: number;
+  commentsCount?: number;
+  user: {
+    publicId: string;
+    handle: string;
+    username: string;
+    avatar: string;
+  };
+  image?: {
+    publicId: string;
+    url: string;
+    slug?: string;
+  } | null;
+}
+
 export interface FeedPost {
   publicId: string;
   body: string;
   slug: string;
+  type?: "original" | "repost";
+  repostCount?: number;
+  repostOf?: FeedPostRepost | null;
   createdAt: Date;
   likes: number;
   commentsCount: number;

--- a/frontend/cypress/e2e/feed-regressions.cy.ts
+++ b/frontend/cypress/e2e/feed-regressions.cy.ts
@@ -1,0 +1,122 @@
+const basePost = {
+	tags: [],
+	likes: 0,
+	commentsCount: 0,
+	viewsCount: 0,
+	isLikedByViewer: false,
+	isFavoritedByViewer: false,
+	isRepostedByViewer: false,
+};
+
+describe("Feed rendering regressions", () => {
+	beforeEach(() => {
+		cy.clearCookies();
+		cy.clearLocalStorage();
+	});
+
+	it("renders repost content in the Latest feed on first load", () => {
+		cy.intercept("GET", "**/api/feed/new*", {
+			statusCode: 200,
+			body: {
+				data: [
+					{
+						...basePost,
+						publicId: "repost-entry",
+						body: "",
+						type: "repost",
+						repostCount: 0,
+						createdAt: "2026-03-01T12:00:00.000Z",
+						user: {
+							publicId: "sharing-user",
+							handle: "sharer",
+							username: "Sharer",
+							avatar: "",
+						},
+						repostOf: {
+							publicId: "original-post",
+							body: "Original body",
+							user: {
+								publicId: "original-user",
+								handle: "original",
+								username: "Original Author",
+								avatar: "",
+							},
+							image: null,
+							likes: 0,
+							repostCount: 0,
+							commentsCount: 0,
+						},
+						image: null,
+						community: null,
+					},
+				],
+				page: 1,
+				limit: 10,
+				total: 1,
+				totalPages: 1,
+				hasMore: false,
+			},
+		}).as("latestFeed");
+
+		cy.visit("/discover");
+		cy.wait("@latestFeed");
+		cy.contains("Reposted from Original Author").should("be.visible");
+		cy.contains("Original body").should("be.visible");
+	});
+
+	it("does not render a community placeholder for standalone profile posts", () => {
+		const profile = {
+			publicId: "profile-user",
+			handle: "plain-user",
+			username: "Plain User",
+			avatar: "",
+			cover: "",
+			bio: "",
+			createdAt: "2026-01-01T12:00:00.000Z",
+			postCount: 1,
+			followerCount: 0,
+			followingCount: 0,
+		};
+
+		cy.intercept("GET", "**/api/users/profile/plain-user", profile).as("profile");
+		cy.intercept("GET", "**/api/posts/user/profile-user*", {
+			data: [
+				{
+					...basePost,
+					publicId: "standalone-post",
+					body: "Standalone post",
+					type: "original",
+					repostCount: 0,
+					createdAt: "2026-01-02T12:00:00.000Z",
+					user: {
+						publicId: "profile-user",
+						handle: "plain-user",
+						username: "Plain User",
+						avatar: "",
+					},
+					image: null,
+					community: {},
+				},
+			],
+			total: 1,
+			page: 1,
+			limit: 10,
+			totalPages: 1,
+			profile,
+		}).as("profilePosts");
+
+		cy.visit("/profile/plain-user");
+		cy.wait(["@profile", "@profilePosts"]);
+		cy.get("main").within(() => {
+			cy.contains("Standalone post").should("be.visible");
+			cy.get('[data-testid="GroupsIcon"]').should("not.exist");
+		});
+	});
+
+	it("uses document scrolling on mobile so native pull-to-refresh can run", () => {
+		cy.viewport(390, 844);
+		cy.visit("/");
+		cy.get("body").should("have.css", "overscroll-behavior-y", "auto");
+		cy.get("main").should("have.css", "overflow", "visible");
+	});
+});

--- a/frontend/cypress/e2e/guest-home.cy.ts
+++ b/frontend/cypress/e2e/guest-home.cy.ts
@@ -1,0 +1,13 @@
+describe("Guest home", () => {
+	beforeEach(() => {
+		cy.clearCookies();
+		cy.clearLocalStorage();
+		cy.visit("/");
+	});
+
+	it("renders the translated guest call to action", () => {
+		cy.contains("Discover what moves people").should("be.visible");
+		cy.contains("New to Ascendance?").should("be.visible");
+		cy.get("body").should("not.contain.text", "marketing.new_to_ascendance");
+	});
+});

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"ignoreDeprecations": "6.0",
+		"types": ["cypress", "node"]
+	},
+	"include": ["**/*.ts", "../cypress.config.ts"]
+}

--- a/frontend/src/api/userApi.ts
+++ b/frontend/src/api/userApi.ts
@@ -12,6 +12,7 @@ import {
 } from "../types";
 import axios, { AxiosError } from "axios";
 import { devError } from "@/lib/devLogger";
+import { mapPost } from "@/lib/mappers";
 
 /** Wraps an async API call, logging any error in development before re-throwing. */
 async function withDevError<T>(label: string, fn: () => Promise<T>): Promise<T> {
@@ -116,7 +117,10 @@ export const fetchUserPosts = (
   withDevError("Error fetching user posts:", () =>
     axiosClient
       .get<ImagePageData>(`/api/posts/user/${userPublicId}?page=${page}&limit=${limit}&sortBy=${sortBy}&sortOrder=${sortOrder}`)
-      .then((r) => r.data),
+      .then((r) => ({
+        ...r.data,
+        data: r.data.data.map(mapPost),
+      })),
   );
 
 export const fetchUserLikedPosts = (
@@ -129,7 +133,10 @@ export const fetchUserLikedPosts = (
   withDevError("Error fetching user liked posts:", () =>
     axiosClient
       .get<ImagePageData>(`/api/posts/user/${userPublicId}/likes?page=${page}&limit=${limit}&sortBy=${sortBy}&sortOrder=${sortOrder}`)
-      .then((r) => r.data),
+      .then((r) => ({
+        ...r.data,
+        data: r.data.data.map(mapPost),
+      })),
   );
 
 export const fetchUserComments = (

--- a/frontend/src/components/LeftSidebar.tsx
+++ b/frontend/src/components/LeftSidebar.tsx
@@ -179,34 +179,53 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({ onPostClick }) => {
 				height: "100%",
 				display: "flex",
 				flexDirection: "column",
-				px: 2,
+				px: { md: 1.5, lg: 2 },
+				py: 1,
 			}}
 		>
 			{/* Logo Section */}
 			<Box
+				component={RouterLink}
+				to="/"
 				sx={{
-					py: 2,
-					px: 1,
+					py: 1.5,
+					px: { md: 0, lg: 1 },
 					display: "flex",
 					alignItems: "center",
+					justifyContent: { md: "center", lg: "flex-start" },
+					gap: 1.5,
+					textDecoration: "none",
 				}}
 			>
-				<Avatar
-					component={RouterLink}
-					to="/"
+				<Box
 					sx={{
-						bgcolor: "transparent",
-						width: 50,
-						height: 50,
-						cursor: "pointer",
+						width: 44,
+						height: 44,
+						borderRadius: 3,
+						display: "grid",
+						placeItems: "center",
+						background: "linear-gradient(145deg, #38bdf8 0%, #8b5cf6 100%)",
+						boxShadow: "0 10px 30px rgba(56, 189, 248, 0.18)",
+						transition: "transform 0.2s ease, box-shadow 0.2s ease",
 						"&:hover": {
-							bgcolor: alpha(theme.palette.primary.main, 0.1),
+							transform: "translateY(-1px)",
+							boxShadow: "0 12px 34px rgba(139, 92, 246, 0.24)",
 						},
-						transition: "background-color 0.2s ease",
 					}}
 				>
-					<CameraAltIcon sx={{ fontSize: 30, color: theme.palette.primary.main }} />
-				</Avatar>
+					<CameraAltIcon sx={{ fontSize: 25, color: "#ffffff" }} />
+				</Box>
+				<Box sx={{ display: { md: "none", lg: "block" }, minWidth: 0 }}>
+					<Typography
+						variant="h6"
+						sx={{ fontWeight: 800, lineHeight: 1.1, letterSpacing: "-0.03em" }}
+					>
+						Ascendance
+					</Typography>
+					<Typography variant="caption" color="text.secondary">
+						{t("marketing.subtitle")}
+					</Typography>
+				</Box>
 			</Box>
 
 			{/* Navigation Section */}
@@ -294,21 +313,37 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({ onPostClick }) => {
 				) : (
 					<Box
 						sx={{
-							p: 3,
-							textAlign: "center",
-							display: "flex",
+							p: 2.5,
+							mt: 3,
+							textAlign: "left",
+							display: { md: "none", lg: "flex" },
 							flexDirection: "column",
-							gap: 2,
+							gap: 1.5,
+							border: `1px solid ${theme.palette.divider}`,
+							borderRadius: 4,
+							background: `linear-gradient(145deg, ${alpha(theme.palette.primary.main, 0.11)}, ${alpha(theme.palette.secondary.main, 0.07)} 65%, transparent)`,
 						}}
 					>
-						<Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+						<Typography
+							variant="overline"
+							sx={{ color: "primary.light", fontWeight: 800, letterSpacing: "0.14em", lineHeight: 1.2 }}
+						>
+							{t("marketing.welcome_label")}
+						</Typography>
+						<Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.6, mb: 0.5 }}>
 							{t("auth.sign_in_prompt")}
 						</Typography>
-						<Button component={RouterLink} to="/login" variant="outlined" fullWidth sx={{ borderRadius: 9999 }}>
-							{t("auth.login")}
-						</Button>
-						<Button component={RouterLink} to="/register" variant="contained" fullWidth sx={{ borderRadius: 9999 }}>
+						<Button
+							component={RouterLink}
+							to="/register"
+							variant="contained"
+							fullWidth
+							sx={{ py: 1.15, background: "linear-gradient(90deg, #0ea5e9, #7c3aed)" }}
+						>
 							{t("auth.join")}
+						</Button>
+						<Button component={RouterLink} to="/login" variant="text" fullWidth sx={{ color: "text.primary" }}>
+							{t("auth.login")}
 						</Button>
 					</Box>
 				)}

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box } from "@mui/material";
+import { Box, alpha, useTheme } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { IPost } from "../types";
@@ -25,6 +25,7 @@ interface PostCardProps {
 const PostCard: React.FC<PostCardProps> = ({ post, prioritizeImage = false }) => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const theme = useTheme();
 	const { isLoggedIn, user } = useAuth();
 	const { mutate: triggerRepost } = useRepostPost();
 	const { mutate: triggerUnrepost } = useUnrepostPost();
@@ -71,13 +72,21 @@ const PostCard: React.FC<PostCardProps> = ({ post, prioritizeImage = false }) =>
 	return (
 		<Box
 			sx={{
-				width: "100%",
-				borderBottom: "1px solid",
-				borderColor: "divider",
+				width: { xs: "100%", sm: "calc(100% - 24px)" },
+				mx: { xs: 0, sm: 1.5 },
+				mt: { xs: 0, sm: 1.5 },
+				border: { xs: "none", sm: `1px solid ${theme.palette.divider}` },
+				borderBottom: { xs: `1px solid ${theme.palette.divider}`, sm: undefined },
+				borderRadius: { xs: 0, sm: 4 },
+				overflow: "hidden",
+				bgcolor: alpha(theme.palette.background.paper, 0.58),
+				boxShadow: { xs: "none", sm: "0 16px 45px rgba(0, 0, 0, 0.12)" },
 				cursor: "pointer",
-				transition: "background-color 0.2s",
+				transition: "background-color 0.2s, border-color 0.2s, transform 0.2s",
 				"&:hover": {
-					bgcolor: "rgba(255, 255, 255, 0.03)",
+					bgcolor: alpha(theme.palette.background.paper, 0.82),
+					borderColor: alpha(theme.palette.primary.main, 0.28),
+					transform: { xs: "none", sm: "translateY(-1px)" },
 				},
 			}}
 			onClick={() => navigate(`/posts/${post.publicId}`)}

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { Box, Typography, alpha, useTheme } from "@mui/material";
+import { Box, Button, Typography, alpha, useTheme } from "@mui/material";
+import ArrowForwardRoundedIcon from "@mui/icons-material/ArrowForwardRounded";
+import { Link as RouterLink } from "react-router-dom";
 import WhoToFollow from "./WhoToFollow";
 import SearchBox from "./SearchBox";
 import TrendingTags from "./TrendingTags";
@@ -17,7 +19,7 @@ const RightSidebar: React.FC = () => {
       sx={{
         display: "flex",
         flexDirection: "column",
-        gap: 2,
+        gap: 2.25,
         pb: 4,
         height: "100%",
       }}
@@ -28,9 +30,9 @@ const RightSidebar: React.FC = () => {
           position: "sticky",
           top: 0,
           zIndex: 10,
-          bgcolor: "background.default",
-          pb: 1,
-          pt: 1,
+          bgcolor: "transparent",
+          pb: 1.25,
+          pt: 1.5,
         }}
       >
         <SearchBox />
@@ -39,10 +41,11 @@ const RightSidebar: React.FC = () => {
       {/* Trending Tags */}
       <Box
         sx={{
-          bgcolor: alpha(theme.palette.background.paper, 0.5),
-          borderRadius: 4,
+          bgcolor: alpha(theme.palette.background.paper, 0.82),
+          borderRadius: 5,
           overflow: "hidden",
           border: `1px solid ${theme.palette.divider}`,
+          boxShadow: "0 20px 50px rgba(0, 0, 0, 0.18)",
         }}
       >
         <TrendingTags />
@@ -52,8 +55,8 @@ const RightSidebar: React.FC = () => {
       {isLoggedIn && (
         <Box
           sx={{
-            bgcolor: alpha(theme.palette.background.paper, 0.5),
-            borderRadius: 4,
+            bgcolor: alpha(theme.palette.background.paper, 0.82),
+            borderRadius: 5,
             overflow: "hidden",
             border: `1px solid ${theme.palette.divider}`,
           }}
@@ -67,17 +70,47 @@ const RightSidebar: React.FC = () => {
         <Box
           sx={{
             p: 3,
-            borderRadius: 4,
+            borderRadius: 5,
             border: `1px solid ${theme.palette.divider}`,
-            textAlign: "center",
+            textAlign: "left",
+            overflow: "hidden",
+            position: "relative",
+            background: `linear-gradient(145deg, ${alpha(theme.palette.primary.main, 0.14)}, ${alpha(theme.palette.secondary.main, 0.09)} 55%, ${alpha(theme.palette.background.paper, 0.88)})`,
+            boxShadow: "0 20px 50px rgba(0, 0, 0, 0.18)",
+            "&::after": {
+              content: '""',
+              position: "absolute",
+              width: 130,
+              height: 130,
+              borderRadius: "50%",
+              right: -70,
+              top: -75,
+              background: alpha(theme.palette.primary.main, 0.13),
+              filter: "blur(2px)",
+            },
           }}
         >
-          <Typography variant="h6" sx={{ mb: 1, fontWeight: 700 }}>
-            {t("marketing.new_to_Ascendance")}
+          <Typography
+            variant="overline"
+            sx={{ color: "primary.light", fontWeight: 800, letterSpacing: "0.14em" }}
+          >
+            {t("marketing.guest_cta_eyebrow")}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="h5" sx={{ mt: 0.5, mb: 1, fontWeight: 800, letterSpacing: "-0.03em" }}>
+            {t("marketing.new_to_ascendance")}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.6, mb: 2.25 }}>
             {t("marketing.sign_up_timeline")}
           </Typography>
+          <Button
+            component={RouterLink}
+            to="/register"
+            variant="contained"
+            endIcon={<ArrowForwardRoundedIcon />}
+            sx={{ px: 2.25, py: 1, background: "linear-gradient(90deg, #0ea5e9, #7c3aed)" }}
+          >
+            {t("auth.join")}
+          </Button>
         </Box>
       )}
     </Box>

--- a/frontend/src/components/TrendingTags.tsx
+++ b/frontend/src/components/TrendingTags.tsx
@@ -61,8 +61,9 @@ const TrendingTags: React.FC = () => {
               px: 2,
               py: 1.5,
               display: "block",
+              borderTop: `1px solid ${alpha(theme.palette.divider, 0.55)}`,
               "&:hover": {
-                backgroundColor: alpha(theme.palette.text.primary, 0.03),
+                backgroundColor: alpha(theme.palette.primary.main, 0.06),
               },
             }}
           >
@@ -71,7 +72,7 @@ const TrendingTags: React.FC = () => {
               color="text.secondary"
               display="block"
             >
-              Trending
+              {t("common.trending_label")}
             </Typography>
             <Typography variant="body1" fontWeight={700} display="block">
               #{trendingTag.tag}
@@ -81,7 +82,7 @@ const TrendingTags: React.FC = () => {
               color="text.secondary"
               display="block"
             >
-              {trendingTag.count} posts
+              {t("common.post_count", { count: trendingTag.count })}
             </Typography>
           </ListItemButton>
         ))}

--- a/frontend/src/components/layout/DesktopAppShell.tsx
+++ b/frontend/src/components/layout/DesktopAppShell.tsx
@@ -29,7 +29,7 @@ export const DesktopAppShell: React.FC<DesktopAppShellProps> = ({
 				height: isMessagesPage ? "100vh" : "auto",
 				minHeight: "100vh",
 				display: "flex",
-				bgcolor: "background.default",
+				bgcolor: "transparent",
 				justifyContent: "center",
 				overflow: isMessagesPage ? "hidden" : "visible",
 			}}
@@ -38,14 +38,14 @@ export const DesktopAppShell: React.FC<DesktopAppShellProps> = ({
 				sx={{
 					display: "flex",
 					width: "100%",
-					maxWidth: "1280px",
+					maxWidth: "1340px",
 					height: isMessagesPage ? "100%" : "auto",
 				}}
 			>
 				<Box
 					component="header"
 					sx={{
-						width: { md: 88, lg: 275 },
+						width: { md: 88, lg: 260 },
 						flexShrink: 0,
 						display: "flex",
 						flexDirection: "column",
@@ -56,9 +56,8 @@ export const DesktopAppShell: React.FC<DesktopAppShellProps> = ({
 						sx={{
 							position: "fixed",
 							height: "100vh",
-							width: { md: 88, lg: 275 },
+							width: { md: 88, lg: 260 },
 							zIndex: 10,
-							borderRight: `1px solid ${theme.palette.divider}`,
 						}}
 					>
 						<LeftSidebar onPostClick={onOpenUploadModal} />
@@ -74,11 +73,17 @@ export const DesktopAppShell: React.FC<DesktopAppShellProps> = ({
 						flexDirection: "column",
 						minWidth: 0,
 						minHeight: 0,
+						bgcolor: "rgba(7, 9, 13, 0.72)",
+						backdropFilter: "blur(18px)",
+						borderLeft:
+							!isMessagesPage && !isAdminPage && !isSettingsPage
+								? `1px solid ${theme.palette.divider}`
+								: "none",
 						borderRight:
 							!isMessagesPage && !isAdminPage && !isSettingsPage
 								? `1px solid ${theme.palette.divider}`
 								: "none",
-						maxWidth: isMessagesPage || isAdminPage ? "100%" : isSettingsPage ? 900 : 600,
+						maxWidth: isMessagesPage || isAdminPage ? "100%" : isSettingsPage ? 900 : 640,
 						width: "100%",
 						height: isMessagesPage ? "100%" : "auto",
 						overflow: isMessagesPage ? "hidden" : "visible",
@@ -90,8 +95,8 @@ export const DesktopAppShell: React.FC<DesktopAppShellProps> = ({
 				{!isMessagesPage && !isAdminPage && !isSettingsPage && (
 					<Box
 						sx={{
-							marginLeft: 3,
-							width: 350,
+							marginLeft: 3.5,
+							width: 360,
 							flexShrink: 0,
 							display: { xs: "none", md: "none", lg: "block" },
 						}}
@@ -100,7 +105,7 @@ export const DesktopAppShell: React.FC<DesktopAppShellProps> = ({
 							sx={{
 								position: "fixed",
 								height: "100vh",
-								width: 350,
+								width: 360,
 								zIndex: 10,
 								overflowY: "auto",
 							}}

--- a/frontend/src/components/mobile/MobileLayout.tsx
+++ b/frontend/src/components/mobile/MobileLayout.tsx
@@ -59,7 +59,7 @@ const MobileLayout: React.FC = () => {
 		<Box
 			sx={{
 				minHeight: "100dvh",
-				height: "100dvh",
+				height: isMessagesPage ? "100dvh" : "auto",
 				display: "flex",
 				flexDirection: "column",
 				bgcolor: "background.default",
@@ -67,7 +67,7 @@ const MobileLayout: React.FC = () => {
 				overflowX: "hidden",
 				"@supports not (min-height: 100dvh)": {
 					minHeight: "100vh",
-					height: "100vh",
+					height: isMessagesPage ? "100vh" : "auto",
 				},
 			}}
 		>
@@ -94,7 +94,7 @@ const MobileLayout: React.FC = () => {
 					minWidth: 0,
 					minHeight: 0,
 					// messages page handles its own scroll, others can overflow
-					overflow: isMessagesPage ? "hidden" : "auto",
+					overflow: isMessagesPage ? "hidden" : "visible",
 					// padding for FAB (only when not on messages page)
 					pb: showFAB ? "80px" : "env(safe-area-inset-bottom)",
 				}}

--- a/frontend/src/components/post-card/PostCardCommunityBadge.tsx
+++ b/frontend/src/components/post-card/PostCardCommunityBadge.tsx
@@ -13,8 +13,9 @@ export const PostCardCommunityBadge: React.FC<PostCardCommunityBadgeProps> = ({
 	communityAvatarUrl,
 }) => {
 	const navigate = useNavigate();
+	const community = post.community;
 
-	if (!post.community) {
+	if (!community?.publicId || !community.name || !community.slug) {
 		return null;
 	}
 
@@ -30,12 +31,10 @@ export const PostCardCommunityBadge: React.FC<PostCardCommunityBadgeProps> = ({
 			}}
 			onClick={(event) => {
 				event.stopPropagation();
-				if (post.community?.slug) {
-					navigate(`/communities/${post.community.slug}`);
-				}
+				navigate(`/communities/${community.slug}`);
 			}}
 		>
-			{post.community.avatar ? (
+			{community.avatar ? (
 				<Avatar src={communityAvatarUrl ?? undefined} sx={{ width: 16, height: 16 }} />
 			) : (
 				<GroupsIcon sx={{ fontSize: 16, color: "primary.main" }} />
@@ -49,7 +48,7 @@ export const PostCardCommunityBadge: React.FC<PostCardCommunityBadgeProps> = ({
 					"&:hover": { textDecoration: "underline" },
 				}}
 			>
-				{post.community.name}
+				{community.name}
 			</Typography>
 		</Box>
 	);

--- a/frontend/src/components/post-card/PostCardHeader.tsx
+++ b/frontend/src/components/post-card/PostCardHeader.tsx
@@ -36,16 +36,16 @@ export const PostCardHeader: React.FC<PostCardHeaderProps> = ({
 	return (
 		<Box
 			sx={{
-				px: 2,
-				pt: hasCommunity ? 0.5 : 1.5,
-				pb: 1,
+				px: { xs: 2, sm: 2.25 },
+				pt: hasCommunity ? 0.5 : 2,
+				pb: 1.25,
 				display: "flex",
 				alignItems: "flex-start",
 				gap: 1.5,
 			}}
 		>
 			<Avatar
-				sx={{ width: 40, height: 40, cursor: "pointer" }}
+				sx={{ width: 42, height: 42, cursor: "pointer", border: "1px solid", borderColor: "divider" }}
 				onClick={(event) => {
 					event.stopPropagation();
 					navigate(`/profile/${post.user?.handle || post.user?.publicId}`);
@@ -74,7 +74,7 @@ export const PostCardHeader: React.FC<PostCardHeaderProps> = ({
 						})}
 					</Typography>
 				)}
-				<Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+				<Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 0.75, minWidth: 0 }}>
 					<Typography
 						variant="body1"
 						sx={{
@@ -89,6 +89,11 @@ export const PostCardHeader: React.FC<PostCardHeaderProps> = ({
 					>
 						{post.user?.username || t("post.unknown_user")}
 					</Typography>
+					{post.user?.handle && (
+						<Typography variant="body2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
+							@{post.user.handle}
+						</Typography>
+					)}
 					{post.authorCommunityRole === "admin" && (
 						<Chip
 							icon={<AdminPanelSettingsIcon sx={{ fontSize: 14 }} />}
@@ -112,8 +117,8 @@ export const PostCardHeader: React.FC<PostCardHeaderProps> = ({
 							sx={{ height: 18, fontSize: "0.65rem" }}
 						/>
 					)}
-					<Typography variant="body2" color="text.secondary">
-						{new Date(post.createdAt).toLocaleDateString(undefined, {
+					<Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>
+						· {new Date(post.createdAt).toLocaleDateString(undefined, {
 							month: "short",
 							day: "numeric",
 						})}

--- a/frontend/src/components/post-card/PostCardImage.tsx
+++ b/frontend/src/components/post-card/PostCardImage.tsx
@@ -21,7 +21,7 @@ export const PostCardImage: React.FC<PostCardImageProps> = ({
 		<Box
 			sx={{
 				mt: 1.5,
-				borderRadius: 3,
+				borderRadius: 3.5,
 				overflow: "hidden",
 				border: "1px solid",
 				borderColor: "divider",
@@ -29,7 +29,7 @@ export const PostCardImage: React.FC<PostCardImageProps> = ({
 				maxHeight: "600px",
 				display: "flex",
 				justifyContent: "center",
-				bgcolor: "black",
+				bgcolor: "#05070a",
 			}}
 		>
 			<img

--- a/frontend/src/components/post-card/PostCardStats.tsx
+++ b/frontend/src/components/post-card/PostCardStats.tsx
@@ -23,16 +23,21 @@ export const PostCardStats: React.FC<PostCardStatsProps> = ({
 				display: "flex",
 				justifyContent: "space-between",
 				maxWidth: 520,
-				mt: 1.5,
+				mt: 1.75,
+				mx: -0.75,
 			}}
 		>
 			<Box
 				sx={{
 					display: "flex",
 					alignItems: "center",
-					gap: 0.5,
+					gap: 0.75,
+					minWidth: 48,
+					px: 0.75,
+					py: 0.5,
+					borderRadius: 999,
 					color: "text.secondary",
-					"&:hover": { color: "#0ea5e9" },
+					"&:hover": { color: "#f43f5e", bgcolor: "rgba(244, 63, 94, 0.1)" },
 				}}
 			>
 				<FavoriteIcon fontSize="small" sx={{ fontSize: 18 }} />
@@ -42,9 +47,13 @@ export const PostCardStats: React.FC<PostCardStatsProps> = ({
 				sx={{
 					display: "flex",
 					alignItems: "center",
-					gap: 0.5,
+					gap: 0.75,
+					minWidth: 48,
+					px: 0.75,
+					py: 0.5,
+					borderRadius: 999,
 					color: hasReposted ? "#22c55e" : "text.secondary",
-					"&:hover": { color: "#22c55e" },
+					"&:hover": { color: "#22c55e", bgcolor: "rgba(34, 197, 94, 0.1)" },
 					cursor: "pointer",
 				}}
 				onClick={onRepostClick}
@@ -56,9 +65,13 @@ export const PostCardStats: React.FC<PostCardStatsProps> = ({
 				sx={{
 					display: "flex",
 					alignItems: "center",
-					gap: 0.5,
+					gap: 0.75,
+					minWidth: 48,
+					px: 0.75,
+					py: 0.5,
+					borderRadius: 999,
 					color: "text.secondary",
-					"&:hover": { color: "#3b82f6" },
+					"&:hover": { color: "#38bdf8", bgcolor: "rgba(56, 189, 248, 0.1)" },
 				}}
 			>
 				<CommentIcon fontSize="small" sx={{ fontSize: 18 }} />
@@ -68,9 +81,13 @@ export const PostCardStats: React.FC<PostCardStatsProps> = ({
 				sx={{
 					display: "flex",
 					alignItems: "center",
-					gap: 0.5,
+					gap: 0.75,
+					minWidth: 48,
+					px: 0.75,
+					py: 0.5,
+					borderRadius: 999,
 					color: "text.secondary",
-					"&:hover": { color: "#0ea5e9" },
+					"&:hover": { color: "#a78bfa", bgcolor: "rgba(139, 92, 246, 0.1)" },
 				}}
 			>
 				<VisibilityIcon fontSize="small" sx={{ fontSize: 18 }} />

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -10,6 +10,10 @@ const resources = {
         subtitle: "See what's happening right now.",
         new_to_ascendance: "New to Ascendance?",
         sign_up_timeline: "Sign up now to get your own personalized timeline!",
+        guest_feed_title: "Discover what moves people",
+        guest_feed_subtitle: "Fresh perspectives, creative work, and communities worth joining.",
+        welcome_label: "Welcome",
+        guest_cta_eyebrow: "Your feed, your people",
       },
       auth: {
         login: "Login",
@@ -40,6 +44,9 @@ const resources = {
         who_to_follow: "Who to follow",
         no_suggestions_right_now: "Check back later for new people to follow",
         trends_for_you: "Trending now",
+        trending_label: "Trending",
+        post_count_one: "{{count}} post",
+        post_count_other: "{{count}} posts",
         language: "Language",
         show_more: "Show more",
         follow: "Follow",
@@ -111,6 +118,10 @@ const resources = {
         new_to_ascendance: "Нови сте в Ascendance?",
         sign_up_timeline:
           "Регистрирайте се сега, за да получите своя персонализирана времева линия!",
+        guest_feed_title: "Открийте какво вдъхновява хората",
+        guest_feed_subtitle: "Нови гледни точки, творчески идеи и общности, към които си струва да се присъедините.",
+        welcome_label: "Добре дошли",
+        guest_cta_eyebrow: "Вашата емисия, вашите хора",
       },
       auth: {
         login: "Вход",
@@ -142,6 +153,9 @@ const resources = {
         no_suggestions_right_now:
           "Проверете по-късно за нови хора за последване",
         trends_for_you: "Актуално сега",
+        trending_label: "Актуално",
+        post_count_one: "{{count}} публикация",
+        post_count_other: "{{count}} публикации",
         language: "Език",
         show_more: "Виж повече",
         follow: "Последвай",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,15 +25,19 @@ html {
 
 body {
 	margin: 0;
-	background: #000000;
+	background:
+		radial-gradient(circle at 18% -10%, rgba(56, 189, 248, 0.1), transparent 30rem),
+		radial-gradient(circle at 88% 0%, rgba(139, 92, 246, 0.08), transparent 26rem),
+		#07090d;
+	background-attachment: fixed;
 	color: #e7e9ea;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	overflow-y: scroll;
 	min-height: 100%;
 	min-height: -webkit-fill-available;
-	/* prevent pull-to-refresh on mobile */
-	overscroll-behavior-y: contain;
+	/* allow the browser's native pull-to-refresh gesture */
+	overscroll-behavior-y: auto;
 }
 
 /* prevent overscroll/bounce on iOS */
@@ -59,10 +63,10 @@ body {
 	width: 10px;
 }
 ::-webkit-scrollbar-track {
-	background: #000000;
+	background: #07090d;
 }
 ::-webkit-scrollbar-thumb {
-	background: #2f3336;
+	background: #26313d;
 	border-radius: 9999px;
 }
 ::-webkit-scrollbar-thumb:hover {

--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -2,24 +2,73 @@ import React, { useMemo } from "react";
 import { usePosts } from "../hooks/posts/usePosts";
 import Gallery from "../components/Gallery";
 import CreatePost from "../components/CreatePost";
-import { Box, Typography, useMediaQuery, useTheme, Card, Skeleton, CardActions } from "@mui/material";
+import { Box, Typography, useMediaQuery, useTheme, Card, Skeleton, CardActions, alpha } from "@mui/material";
+import AutoAwesomeRoundedIcon from "@mui/icons-material/AutoAwesomeRounded";
 import { PageSeo } from "../lib/PageSeo";
 import { buildHomeMetadata } from "../lib/seo";
+import { useAuth } from "../hooks/context/useAuth";
+import { useTranslation } from "react-i18next";
 
 const Home: React.FC = () => {
 	const theme = useTheme();
 	const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+	const { isLoggedIn } = useAuth();
+	const { t } = useTranslation();
 
 	// backend picks personalized vs trending based on auth present in the request
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = usePosts();
 
 	const activePosts = useMemo(() => data?.pages.flatMap((p) => p.data) ?? [], [data]);
+	const feedHeader = (
+		<Box
+			component="header"
+			sx={{
+				position: "sticky",
+				top: 0,
+				zIndex: 4,
+				display: "flex",
+				alignItems: "center",
+				gap: 1.5,
+				px: 2.5,
+				py: 1.75,
+				borderBottom: `1px solid ${theme.palette.divider}`,
+				bgcolor: alpha(theme.palette.background.default, 0.82),
+				backdropFilter: "blur(18px)",
+			}}
+		>
+			<Box
+				sx={{
+					width: 38,
+					height: 38,
+					borderRadius: 2.5,
+					display: "grid",
+					placeItems: "center",
+					flexShrink: 0,
+					background: "linear-gradient(145deg, rgba(56, 189, 248, 0.22), rgba(139, 92, 246, 0.2))",
+					border: `1px solid ${alpha(theme.palette.primary.main, 0.24)}`,
+				}}
+			>
+				<AutoAwesomeRoundedIcon sx={{ fontSize: 20, color: "primary.light" }} />
+			</Box>
+			<Box sx={{ minWidth: 0 }}>
+				<Typography variant="h6" sx={{ fontWeight: 800, letterSpacing: "-0.025em", lineHeight: 1.25 }}>
+					{isLoggedIn ? t("nav.home") : t("marketing.guest_feed_title")}
+				</Typography>
+				{!isLoggedIn && (
+					<Typography variant="body2" color="text.secondary" noWrap>
+						{t("marketing.guest_feed_subtitle")}
+					</Typography>
+				)}
+			</Box>
+		</Box>
+	);
 
 	if (isLoading) {
 		return (
 			<>
 				<PageSeo {...buildHomeMetadata()} />
-				<Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", mt: 2 }}>
+				{feedHeader}
+				<Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", mt: 1.5 }}>
 					<Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%" }}>
 						{Array.from({ length: 3 }).map((_, i) => (
 							<Card
@@ -47,9 +96,14 @@ const Home: React.FC = () => {
 	return (
 		<>
 			<PageSeo {...buildHomeMetadata()} />
-			<Box sx={{ display: "flex", flexDirection: "column", mt: 2 }}>
+			<Box sx={{ display: "flex", flexDirection: "column" }}>
+				{feedHeader}
 				{/* CreatePost decides whether it should render or not - hide on mobile */}
-				{!isMobile && <CreatePost />}
+				{!isMobile && isLoggedIn && (
+					<Box sx={{ p: 2, borderBottom: `1px solid ${theme.palette.divider}` }}>
+						<CreatePost />
+					</Box>
+				)}
 
 				<Box
 					sx={{

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -4,23 +4,23 @@ export const theme = createTheme({
 	palette: {
 		mode: "dark", // switches MUI internal logic to dark mode
 		primary: {
-			main: "#0ea5e9",
-			light: "#38bdf8",
-			dark: "#0284c7",
+			main: "#38bdf8",
+			light: "#7dd3fc",
+			dark: "#0ea5e9",
 			contrastText: "#ffffff",
 		},
 		secondary: {
-			main: "#71767b",
+			main: "#8b5cf6",
 		},
 		background: {
-			default: "#000000",
-			paper: "#16181c",
+			default: "#07090d",
+			paper: "#0e131a",
 		},
 		text: {
-			primary: "#e7e9ea",
-			secondary: "#71767b",
+			primary: "#f1f5f9",
+			secondary: "#8b98a7",
 		},
-		divider: "#2f3336",
+		divider: "rgba(148, 163, 184, 0.18)",
 	},
 	typography: {
 		fontFamily: '"Open Sans", "Inter", "system-ui", "-apple-system", "BlinkMacSystemFont", "sans-serif"',
@@ -62,7 +62,7 @@ export const theme = createTheme({
 		MuiCssBaseline: {
 			styleOverrides: {
 				body: {
-					backgroundColor: "#000000",
+					backgroundColor: "#07090d",
 					scrollbarWidth: "thin",
 				},
 			},
@@ -160,10 +160,10 @@ export const theme = createTheme({
 		MuiIconButton: {
 			styleOverrides: {
 				root: {
-					color: "#71767b",
+					color: "#8b98a7",
 					"&:hover": {
-						backgroundColor: "white",
-						color: "#0ea5e9",
+						backgroundColor: "rgba(56, 189, 248, 0.12)",
+						color: "#38bdf8",
 					},
 				},
 			},

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -188,7 +188,7 @@ export interface CommentsPaginationResponse {
 export type PageParam = number;
 
 export type ImagePageData = {
-  data: IImage[];
+  data: IPost[];
   total: number;
   page: number;
   limit: number;


### PR DESCRIPTION
 - Fixed aggregated feeds discarding type, repostOf, and repost metadata. Latest and profile reposts now render immediately.
 - Normalized missing communities/images to `null` with an additional type guards in the React component
 - Restored document-level mobile scrolling and native pull-to-refresh support. Messages retains its dedicated scroll container.
 - Added gradient accents, softer dark surfaces, improved spacing, and a dedicated feed header.
 - Restyled posts for clearer author metadata, imagery, and actions.
 - Improved the trending and signup panels, including correct “1 post” pluralization.
 - Fixed `marketing.new_to_ascendance` by correcting the mismatched capitalization in the right sidebar component. 
 - Added a small guard regression test in a separate file in cypress specifically to confirm the bug no-longer exists. 