### PR TITLE
refactor: Atomic refresh-token rotation

### DIFF
--- a/backend/src/__tests__/integration/atomic-refresh-rotation.integration.test.ts
+++ b/backend/src/__tests__/integration/atomic-refresh-rotation.integration.test.ts
@@ -1,0 +1,956 @@
+import "reflect-metadata";
+import crypto from "crypto";
+import { expect } from "chai";
+import { after, before, beforeEach, describe, it } from "mocha";
+import { createClient, RedisClientType } from "redis";
+import { AuthSessionService } from "@/services/auth-session.service";
+import { RedisService } from "@/services/redis.service";
+import { RedisSessionModule } from "@/services/redis/redis-session.module";
+
+type TestSession = {
+  sid: string;
+  publicId: string;
+  isEmailVerified: boolean;
+  refreshTokenHash: string;
+  previousRefreshTokenHash?: string;
+  previousRefreshTokenGraceUntil?: number;
+  refreshVersion: number;
+  createdAt: number;
+  lastSeenAt: number;
+  status: "active" | "revoked";
+};
+
+describe("Atomic refresh-token rotation integration", function () {
+  this.timeout(30_000);
+
+  let client: RedisClientType;
+  let peerClient: RedisClientType;
+  let sessions: RedisSessionModule;
+  let peerSessions: RedisSessionModule;
+  let authSessions: AuthSessionService;
+  const testPrefix = `atomic-refresh:${process.pid}:`;
+  const trackedSessions = new Map<string, string>();
+
+  const digest = (value: string): string =>
+    crypto.createHash("sha256").update(value, "utf8").digest("hex");
+
+  const expectRejectionMessage = async (
+    promise: Promise<unknown>,
+    message: string,
+  ): Promise<void> => {
+    let rejection: unknown;
+    try {
+      await promise;
+    } catch (error) {
+      rejection = error;
+    }
+    expect(rejection).to.be.instanceOf(Error);
+    expect((rejection as Error).message).to.equal(message);
+  };
+
+  const createStoredSession = async (
+    label: string,
+    publicId = `${testPrefix}user`,
+    overrides: Partial<TestSession> = {},
+  ): Promise<{ session: TestSession; currentHash: string }> => {
+    const sid = crypto.randomUUID();
+    const currentHash = digest(`${testPrefix}${label}:current`);
+    const now = Date.now();
+    const session: TestSession = {
+      sid,
+      publicId,
+      isEmailVerified: true,
+      refreshTokenHash: currentHash,
+      refreshVersion: 0,
+      createdAt: now,
+      lastSeenAt: now,
+      status: "active",
+      ...overrides,
+    };
+
+    trackedSessions.set(sid, publicId);
+    await sessions.saveSession(session, 60);
+    return { session, currentHash };
+  };
+
+  const rotate = (
+    session: TestSession,
+    presentedRefreshTokenHash: string,
+    nextRefreshTokenHash: string,
+    options: {
+      expectedRefreshVersion?: number;
+      now?: number;
+      graceUntil?: number;
+      sessionModule?: RedisSessionModule;
+    } = {},
+  ) => {
+    const now = options.now ?? Date.now();
+    return (options.sessionModule ?? sessions).compareAndRotateSession<TestSession>({
+      sid: session.sid,
+      publicId: session.publicId,
+      presentedRefreshTokenHash,
+      nextRefreshTokenHash,
+      expectedRefreshVersion:
+        options.expectedRefreshVersion ?? session.refreshVersion,
+      now,
+      previousRefreshTokenGraceUntil:
+        options.graceUntil ?? now + 60_000,
+      ttlSeconds: 60,
+    });
+  };
+
+  before(async function () {
+    const redisUrl = process.env.REDIS_URL;
+    if (!redisUrl) {
+      throw new Error(
+        "REDIS_URL is required. Run `npm run test-integration` from the repository root.",
+      );
+    }
+
+    client = createClient({
+      url: redisUrl,
+      socket: { connectTimeout: 3_000, reconnectStrategy: false },
+    });
+    client.on("error", () => undefined);
+    await client.connect();
+    await client.ping();
+    peerClient = createClient({
+      url: redisUrl,
+      socket: { connectTimeout: 3_000, reconnectStrategy: false },
+    });
+    peerClient.on("error", () => undefined);
+    await peerClient.connect();
+    await peerClient.ping();
+    sessions = new RedisSessionModule(client);
+    peerSessions = new RedisSessionModule(peerClient);
+    authSessions = new AuthSessionService({
+      getAuthSession: sessions.getSession.bind(sessions),
+      saveAuthSession: sessions.saveSession.bind(sessions),
+      compareAndRotateAuthSession:
+        sessions.compareAndRotateSession.bind(sessions),
+      revokeAuthSessionByRefreshToken:
+        sessions.revokeRefreshSession.bind(sessions),
+      getUserAuthSessionIds: sessions.getUserSessionIds.bind(sessions),
+      markAuthSessionEmailVerified:
+        sessions.markSessionEmailVerified.bind(sessions),
+      removeAuthSessionMembership:
+        sessions.removeSessionMembership.bind(sessions),
+    } as unknown as RedisService);
+  });
+
+  beforeEach(async () => {
+    for (const [sid, publicId] of trackedSessions) {
+      await sessions.removeSession(sid, publicId);
+    }
+    trackedSessions.clear();
+  });
+
+  after(async () => {
+    for (const [sid, publicId] of trackedSessions) {
+      await sessions.removeSession(sid, publicId);
+    }
+    if (peerClient?.isOpen) {
+      await peerClient.disconnect();
+    }
+    if (client?.isOpen) {
+      await client.disconnect();
+    }
+  });
+
+  it("allows one service-level winner for two simultaneous raw-token rotations", async () => {
+    const sid = crypto.randomUUID();
+    const publicId = `${testPrefix}service-user`;
+    const currentToken = `${sid}.current-secret`;
+    const session = await authSessions.createSession({
+      sid,
+      publicId,
+      isEmailVerified: true,
+      refreshToken: currentToken,
+      ttlSeconds: 60,
+    });
+    trackedSessions.set(sid, publicId);
+    const successors = [
+      `${sid}.successor-a`,
+      `${sid}.successor-b`,
+    ];
+
+    const results = await Promise.allSettled(
+      successors.map((nextToken) =>
+        authSessions.rotateRefreshToken(
+          session,
+          currentToken,
+          nextToken,
+          60,
+        ),
+      ),
+    );
+
+    expect(results.filter((result) => result.status === "fulfilled")).to.have
+      .length(1);
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult =>
+        result.status === "rejected",
+    );
+    expect(rejected?.reason).to.have.property(
+      "message",
+      "Refresh token already rotated",
+    );
+    const stored = await sessions.getSession<TestSession>(sid);
+    expect(stored?.refreshVersion).to.equal(1);
+    expect(successors.map(digest)).to.include(stored?.refreshTokenHash);
+  });
+
+  it("allows exactly one of two simultaneous rotations for one session", async () => {
+    const { session, currentHash } = await createStoredSession("two");
+    const successors = [digest("two:next-a"), digest("two:next-b")];
+    await sessions.removeSessionMembership(session.publicId, session.sid);
+    expect(
+      await client.sIsMember(
+        `user:sessions:${session.publicId}`,
+        session.sid,
+      ),
+    ).to.equal(false);
+
+    const results = await Promise.all(
+      successors.map((nextHash) => rotate(session, currentHash, nextHash)),
+    );
+
+    expect(results.map((result) => result.outcome).sort()).to.deep.equal([
+      "rotated",
+      "stale_previous",
+    ]);
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(successors).to.include(stored?.refreshTokenHash);
+    expect(stored?.previousRefreshTokenHash).to.equal(currentHash);
+    expect(stored?.refreshVersion).to.equal(1);
+    expect(
+      await client.sIsMember(
+        `user:sessions:${session.publicId}`,
+        session.sid,
+      ),
+    ).to.equal(true);
+    expect(await client.ttl(`user:sessions:${session.publicId}`)).to.be.greaterThan(0);
+  });
+
+  it("allows exactly one winner across independent Redis clients", async () => {
+    const { session, currentHash } = await createStoredSession("multi-client");
+    const successors = [
+      digest("multi-client:next-a"),
+      digest("multi-client:next-b"),
+    ];
+
+    const results = await Promise.all([
+      rotate(session, currentHash, successors[0]),
+      rotate(session, currentHash, successors[1], {
+        sessionModule: peerSessions,
+      }),
+    ]);
+
+    expect(results.map((result) => result.outcome).sort()).to.deep.equal([
+      "rotated",
+      "stale_previous",
+    ]);
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(successors).to.include(stored?.refreshTokenHash);
+    expect(stored?.refreshVersion).to.equal(1);
+  });
+
+  it("allows exactly one of ten simultaneous rotations for one session", async () => {
+    const { session, currentHash } = await createStoredSession("ten");
+    const successors = Array.from({ length: 10 }, (_, index) =>
+      digest(`ten:next-${index}`),
+    );
+
+    const results = await Promise.all(
+      successors.map((nextHash) => rotate(session, currentHash, nextHash)),
+    );
+
+    expect(results.filter((result) => result.outcome === "rotated")).to.have
+      .length(1);
+    expect(
+      results.filter((result) => result.outcome === "stale_previous"),
+    ).to.have.length(9);
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(successors).to.include(stored?.refreshTokenHash);
+    expect(stored?.refreshVersion).to.equal(1);
+  });
+
+  it("rotates two distinct sessions for one user independently", async () => {
+    const publicId = `${testPrefix}shared-user`;
+    const first = await createStoredSession("device-a", publicId);
+    const second = await createStoredSession("device-b", publicId);
+
+    const [firstResult, secondResult] = await Promise.all([
+      rotate(first.session, first.currentHash, digest("device-a:next")),
+      rotate(second.session, second.currentHash, digest("device-b:next")),
+    ]);
+
+    expect(firstResult.outcome).to.equal("rotated");
+    expect(secondResult.outcome).to.equal("rotated");
+    expect(
+      (await sessions.getSession<TestSession>(first.session.sid))
+        ?.refreshVersion,
+    ).to.equal(1);
+    expect(
+      (await sessions.getSession<TestSession>(second.session.sid))
+        ?.refreshVersion,
+    ).to.equal(1);
+  });
+
+  it("does not store the losing request's proposed successor", async () => {
+    const { session, currentHash } = await createStoredSession("loser");
+    const successors = [digest("loser:next-a"), digest("loser:next-b")];
+    const results = await Promise.all(
+      successors.map((nextHash) => rotate(session, currentHash, nextHash)),
+    );
+    const losingIndex = results.findIndex(
+      (result) => result.outcome === "stale_previous",
+    );
+    const losingSuccessor = successors[losingIndex];
+
+    const replay = await rotate(
+      { ...session, refreshVersion: 1 },
+      losingSuccessor,
+      digest("loser:replay-next"),
+      { expectedRefreshVersion: 1 },
+    );
+
+    expect(replay.outcome).to.equal("mismatch");
+    expect(await sessions.getSession(session.sid)).to.equal(null);
+  });
+
+  it("classifies the previous token inside grace without changing the winner", async () => {
+    const { session, currentHash } = await createStoredSession("grace-in");
+    const winningHash = digest("grace-in:winner");
+    const first = await rotate(session, currentHash, winningHash);
+    expect(first.outcome).to.equal("rotated");
+
+    const stale = await rotate(
+      { ...session, refreshVersion: 1 },
+      currentHash,
+      digest("grace-in:discarded"),
+      { expectedRefreshVersion: 1 },
+    );
+
+    expect(stale.outcome).to.equal("stale_previous");
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(stored?.refreshTokenHash).to.equal(winningHash);
+    expect(stored?.refreshVersion).to.equal(1);
+  });
+
+  it("rejects previous-token reuse outside grace and revokes the session", async () => {
+    const now = Date.now();
+    const previousHash = digest("grace-out:previous");
+    const { session } = await createStoredSession("grace-out", undefined, {
+      previousRefreshTokenHash: previousHash,
+      previousRefreshTokenGraceUntil: now - 1,
+      refreshVersion: 1,
+    });
+
+    const result = await rotate(
+      session,
+      previousHash,
+      digest("grace-out:next"),
+      { expectedRefreshVersion: 1, now },
+    );
+
+    expect(result.outcome).to.equal("mismatch");
+    expect(await sessions.getSession(session.sid)).to.equal(null);
+  });
+
+  it("returns missing for missing and expired sessions", async () => {
+    const missingSession: TestSession = {
+      sid: crypto.randomUUID(),
+      publicId: `${testPrefix}missing-user`,
+      isEmailVerified: true,
+      refreshTokenHash: digest("missing:current"),
+      refreshVersion: 0,
+      createdAt: Date.now(),
+      lastSeenAt: Date.now(),
+      status: "active",
+    };
+    const missing = await rotate(
+      missingSession,
+      missingSession.refreshTokenHash,
+      digest("missing:next"),
+    );
+    expect(missing.outcome).to.equal("missing");
+
+    const expired = await createStoredSession("expired");
+    await client.pExpire(`session:${expired.session.sid}`, 1);
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+    const expiredResult = await rotate(
+      expired.session,
+      expired.currentHash,
+      digest("expired:next"),
+    );
+    expect(expiredResult.outcome).to.equal("missing");
+    expect(
+      await client.sIsMember(
+        `user:sessions:${expired.session.publicId}`,
+        expired.session.sid,
+      ),
+    ).to.equal(false);
+  });
+
+  it("keeps refresh-token logout atomic when it races with rotation", async () => {
+    const { session, currentHash } = await createStoredSession(
+      "refresh-logout-race",
+    );
+
+    const [rotation, revocation] = await Promise.all([
+      rotate(
+        session,
+        currentHash,
+        digest("refresh-logout-race:next"),
+      ),
+      peerSessions.revokeRefreshSession({
+        sid: session.sid,
+        presentedRefreshTokenHash: currentHash,
+        now: Date.now(),
+      }),
+    ]);
+
+    expect(["rotated", "missing"]).to.include(rotation.outcome);
+    expect(revocation).to.equal("revoked");
+    expect(await sessions.getSession(session.sid)).to.equal(null);
+    expect(
+      await client.sIsMember(
+        `user:sessions:${session.publicId}`,
+        session.sid,
+      ),
+    ).to.equal(false);
+  });
+
+  it("keeps logout immediate in both orderings around rotation", async () => {
+    const before = await createStoredSession("logout-before");
+    await sessions.removeSession(before.session.sid, before.session.publicId);
+    const afterLogout = await rotate(
+      before.session,
+      before.currentHash,
+      digest("logout-before:next"),
+    );
+    expect(afterLogout.outcome).to.equal("missing");
+
+    const after = await createStoredSession("logout-after");
+    const rotation = await rotate(
+      after.session,
+      after.currentHash,
+      digest("logout-after:next"),
+    );
+    await sessions.removeSession(after.session.sid, after.session.publicId);
+    expect(rotation.outcome).to.equal("rotated");
+    expect(await sessions.getSession(after.session.sid)).to.equal(null);
+
+    const concurrent = await createStoredSession("logout-concurrent");
+    const [concurrentRotation] = await Promise.all([
+      rotate(
+        concurrent.session,
+        concurrent.currentHash,
+        digest("logout-concurrent:next"),
+      ),
+      sessions.removeSession(
+        concurrent.session.sid,
+        concurrent.session.publicId,
+      ),
+    ]);
+    expect(["rotated", "missing"]).to.include(concurrentRotation.outcome);
+    expect(await sessions.getSession(concurrent.session.sid)).to.equal(null);
+    expect(
+      await client.sIsMember(
+        `user:sessions:${concurrent.session.publicId}`,
+        concurrent.session.sid,
+      ),
+    ).to.equal(false);
+  });
+
+  it("keeps revoke-all immediate in both orderings around rotation", async () => {
+    const publicId = `${testPrefix}revoke-all-user`;
+    const before = await createStoredSession("revoke-all-before", publicId);
+    await sessions.deleteUserSessions(publicId, [before.session.sid]);
+    const afterRevokeAll = await rotate(
+      before.session,
+      before.currentHash,
+      digest("revoke-all-before:next"),
+    );
+    expect(afterRevokeAll.outcome).to.equal("missing");
+
+    const after = await createStoredSession("revoke-all-after", publicId);
+    const rotation = await rotate(
+      after.session,
+      after.currentHash,
+      digest("revoke-all-after:next"),
+    );
+    await sessions.deleteUserSessions(publicId, [after.session.sid]);
+    expect(rotation.outcome).to.equal("rotated");
+    expect(await sessions.getSession(after.session.sid)).to.equal(null);
+
+    const concurrent = await createStoredSession(
+      "revoke-all-concurrent",
+      publicId,
+    );
+    const [concurrentRotation] = await Promise.all([
+      rotate(
+        concurrent.session,
+        concurrent.currentHash,
+        digest("revoke-all-concurrent:next"),
+      ),
+      sessions.deleteUserSessions(publicId, [concurrent.session.sid]),
+    ]);
+    expect(["rotated", "missing"]).to.include(concurrentRotation.outcome);
+    expect(await sessions.getSession(concurrent.session.sid)).to.equal(null);
+    expect(await client.exists(`user:sessions:${publicId}`)).to.equal(0);
+  });
+
+  it("returns mismatch and revokes when the presented hash is unknown", async () => {
+    const { session } = await createStoredSession("mismatch");
+
+    const result = await rotate(
+      session,
+      digest("mismatch:unknown"),
+      digest("mismatch:next"),
+    );
+
+    expect(result.outcome).to.equal("mismatch");
+    expect(await sessions.getSession(session.sid)).to.equal(null);
+    expect(
+      await client.sIsMember(
+        `user:sessions:${session.publicId}`,
+        session.sid,
+      ),
+    ).to.equal(false);
+  });
+
+  it("returns revoked for a non-active record without mutating it", async () => {
+    const { session, currentHash } = await createStoredSession(
+      "revoked",
+      undefined,
+      { status: "revoked" },
+    );
+
+    const result = await rotate(
+      session,
+      currentHash,
+      digest("revoked:next"),
+    );
+
+    expect(result.outcome).to.equal("revoked");
+    expect(
+      (await sessions.getSession<TestSession>(session.sid))?.refreshTokenHash,
+    ).to.equal(currentHash);
+  });
+
+  it("returns version_conflict without overwriting current refresh state", async () => {
+    const { session, currentHash } = await createStoredSession("version");
+
+    const result = await rotate(
+      session,
+      currentHash,
+      digest("version:next"),
+      { expectedRefreshVersion: 9 },
+    );
+
+    expect(result.outcome).to.equal("version_conflict");
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(stored?.refreshTokenHash).to.equal(currentHash);
+    expect(stored?.refreshVersion).to.equal(0);
+  });
+
+  it("merges delayed metadata into the winning rotation without overwriting it", async () => {
+    const rotatedCase = await createStoredSession("delayed-update", undefined, {
+      isEmailVerified: false,
+    });
+    const winningHash = digest("delayed-update:winner");
+    const rotation = await rotate(
+      rotatedCase.session,
+      rotatedCase.currentHash,
+      winningHash,
+    );
+    expect(rotation.outcome).to.equal("rotated");
+
+    const delayedLastSeenAt = Date.now() + 1_000;
+    expect(
+      await sessions.touchSession({
+        sid: rotatedCase.session.sid,
+        publicId: rotatedCase.session.publicId,
+        lastSeenAt: delayedLastSeenAt,
+      }),
+    ).to.equal("updated");
+    expect(
+      await sessions.markSessionEmailVerified({
+        sid: rotatedCase.session.sid,
+        publicId: rotatedCase.session.publicId,
+      }),
+    ).to.equal("updated");
+
+    const storedWinner = await sessions.getSession<TestSession>(
+      rotatedCase.session.sid,
+    );
+    expect(storedWinner?.refreshTokenHash).to.equal(winningHash);
+    expect(storedWinner?.refreshVersion).to.equal(1);
+    expect(storedWinner?.isEmailVerified).to.equal(true);
+    expect(storedWinner?.lastSeenAt).to.equal(delayedLastSeenAt);
+  });
+
+  it("keeps same-generation metadata monotonic", async () => {
+    const { session } = await createStoredSession("metadata-monotonic", undefined, {
+      isEmailVerified: false,
+    });
+    const olderLastSeenAt = session.lastSeenAt + 1_000;
+    const newerLastSeenAt = session.lastSeenAt + 2_000;
+
+    await sessions.markSessionEmailVerified({
+      sid: session.sid,
+      publicId: session.publicId,
+    });
+    await sessions.touchSession({
+      sid: session.sid,
+      publicId: session.publicId,
+      lastSeenAt: newerLastSeenAt,
+    });
+    await sessions.touchSession({
+      sid: session.sid,
+      publicId: session.publicId,
+      lastSeenAt: olderLastSeenAt,
+    });
+
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(stored?.isEmailVerified).to.equal(true);
+    expect(stored?.lastSeenAt).to.equal(newerLastSeenAt);
+  });
+
+  it("does not let a delayed rotation regress newer activity metadata", async () => {
+    const { session, currentHash } = await createStoredSession(
+      "rotation-activity",
+    );
+    const newerLastSeenAt = session.lastSeenAt + 2_000;
+    await sessions.touchSession({
+      sid: session.sid,
+      publicId: session.publicId,
+      lastSeenAt: newerLastSeenAt,
+    });
+
+    const result = await rotate(
+      session,
+      currentHash,
+      digest("rotation-activity:next"),
+      { now: session.lastSeenAt + 1_000 },
+    );
+
+    expect(result.outcome).to.equal("rotated");
+    expect(
+      (await sessions.getSession<TestSession>(session.sid))?.lastSeenAt,
+    ).to.equal(newerLastSeenAt);
+  });
+
+  it("preserves the live session TTL during metadata updates", async () => {
+    const { session } = await createStoredSession("metadata-ttl", undefined, {
+      isEmailVerified: false,
+    });
+    const sessionKey = `session:${session.sid}`;
+    await client.pExpire(sessionKey, 5_000);
+    const before = await client.pTTL(sessionKey);
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+    await sessions.touchSession({
+      sid: session.sid,
+      publicId: session.publicId,
+      lastSeenAt: session.lastSeenAt + 1_000,
+    });
+    await sessions.markSessionEmailVerified({
+      sid: session.sid,
+      publicId: session.publicId,
+    });
+
+    const after = await client.pTTL(sessionKey);
+    expect(after).to.be.greaterThan(0);
+    expect(after).to.be.lessThan(before);
+  });
+
+  it("preserves verification when it races with rotation across clients", async () => {
+    const { session, currentHash } = await createStoredSession(
+      "verification-rotation",
+      undefined,
+      { isEmailVerified: false },
+    );
+    const winningHash = digest("verification-rotation:winner");
+
+    const [rotation, verification] = await Promise.all([
+      rotate(session, currentHash, winningHash),
+      peerSessions.markSessionEmailVerified({
+        sid: session.sid,
+        publicId: session.publicId,
+      }),
+    ]);
+
+    expect(rotation.outcome).to.equal("rotated");
+    expect(verification).to.equal("updated");
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(stored?.refreshTokenHash).to.equal(winningHash);
+    expect(stored?.refreshVersion).to.equal(1);
+    expect(stored?.isEmailVerified).to.equal(true);
+  });
+
+  it("does not let delayed metadata recreate logout", async () => {
+    const loggedOut = await createStoredSession("delayed-after-logout");
+
+    await sessions.removeSession(
+      loggedOut.session.sid,
+      loggedOut.session.publicId,
+    );
+    expect(
+      await sessions.touchSession({
+        sid: loggedOut.session.sid,
+        publicId: loggedOut.session.publicId,
+        lastSeenAt: Date.now() + 1_000,
+      }),
+    ).to.equal("missing");
+    expect(
+      await sessions.markSessionEmailVerified({
+        sid: loggedOut.session.sid,
+        publicId: loggedOut.session.publicId,
+      }),
+    ).to.equal("missing");
+    expect(await sessions.getSession(loggedOut.session.sid)).to.equal(null);
+  });
+
+  it("preserves a delayed touch when email verification runs second", async () => {
+    const { session } = await createStoredSession("touch-then-verification", undefined, {
+      isEmailVerified: false,
+    });
+    const touchedAt = session.lastSeenAt + 1_000;
+
+    expect(
+      await sessions.touchSession({
+        sid: session.sid,
+        publicId: session.publicId,
+        lastSeenAt: touchedAt,
+      }),
+    ).to.equal("updated");
+    expect(
+      await sessions.markSessionEmailVerified({
+        sid: session.sid,
+        publicId: session.publicId,
+      }),
+    ).to.equal("updated");
+
+    const stored = await sessions.getSession<TestSession>(session.sid);
+    expect(stored?.lastSeenAt).to.equal(touchedAt);
+    expect(stored?.isEmailVerified).to.equal(true);
+    expect(stored?.refreshTokenHash).to.equal(session.refreshTokenHash);
+    expect(
+      await client.sIsMember(`user:sessions:${session.publicId}`, session.sid),
+    ).to.equal(true);
+  });
+
+  it("rejects an embedded SID that conflicts with the addressed Redis key", async () => {
+    const { session } = await createStoredSession("embedded-sid");
+    const conflictingSid = crypto.randomUUID();
+    const raw = JSON.stringify({ ...session, sid: conflictingSid });
+    await client.setEx(`session:${session.sid}`, 60, raw);
+
+    const rotation = await rotate(
+      session,
+      session.refreshTokenHash,
+      digest("embedded-sid:next"),
+    );
+    const touch = await sessions.touchSession({
+      sid: session.sid,
+      publicId: session.publicId,
+      lastSeenAt: session.lastSeenAt + 1_000,
+    });
+    const verification = await sessions.markSessionEmailVerified({
+      sid: session.sid,
+      publicId: session.publicId,
+    });
+
+    expect(rotation.outcome).to.equal("identity_mismatch");
+    expect(touch).to.equal("identity_mismatch");
+    expect(verification).to.equal("identity_mismatch");
+    expect(await client.get(`session:${session.sid}`)).to.equal(raw);
+    expect(
+      await client.sIsMember(`user:sessions:${session.publicId}`, session.sid),
+    ).to.equal(true);
+    await expectRejectionMessage(
+      authSessions.getRefreshSession(`${session.sid}.presented-secret`),
+      "Session is invalid or expired",
+    );
+  });
+
+  it("rejects a stored public ID that differs from the expected identity", async () => {
+    const { session } = await createStoredSession("public-id-mismatch");
+    const expectedPublicId = `${testPrefix}other-user`;
+    const raw = await client.get(`session:${session.sid}`);
+
+    const rotation = await rotate(
+      { ...session, publicId: expectedPublicId },
+      session.refreshTokenHash,
+      digest("public-id-mismatch:next"),
+    );
+    const touch = await sessions.touchSession({
+      sid: session.sid,
+      publicId: expectedPublicId,
+      lastSeenAt: session.lastSeenAt + 1_000,
+    });
+    const verification = await sessions.markSessionEmailVerified({
+      sid: session.sid,
+      publicId: expectedPublicId,
+    });
+
+    expect(rotation.outcome).to.equal("identity_mismatch");
+    expect(touch).to.equal("identity_mismatch");
+    expect(verification).to.equal("identity_mismatch");
+    expect(await client.get(`session:${session.sid}`)).to.equal(raw);
+    expect(
+      await client.sIsMember(`user:sessions:${session.publicId}`, session.sid),
+    ).to.equal(true);
+    expect(
+      await client.sIsMember(`user:sessions:${expectedPublicId}`, session.sid),
+    ).to.equal(false);
+  });
+
+  it("logs out with the previous token after rotation and in both controlled orderings", async () => {
+    const rotationFirst = await createStoredSession("logout-rotation-first");
+    const nextHash = digest("logout-rotation-first:next");
+    expect(
+      (await rotate(rotationFirst.session, rotationFirst.currentHash, nextHash))
+        .outcome,
+    ).to.equal("rotated");
+    expect(
+      await sessions.revokeRefreshSession({
+        sid: rotationFirst.session.sid,
+        presentedRefreshTokenHash: rotationFirst.currentHash,
+        now: Date.now(),
+      }),
+    ).to.equal("revoked");
+    expect(await sessions.getSession(rotationFirst.session.sid)).to.equal(null);
+    expect(
+      await client.sIsMember(
+        `user:sessions:${rotationFirst.session.publicId}`,
+        rotationFirst.session.sid,
+      ),
+    ).to.equal(false);
+
+    const logoutFirst = await createStoredSession("logout-first");
+    expect(
+      await sessions.revokeRefreshSession({
+        sid: logoutFirst.session.sid,
+        presentedRefreshTokenHash: logoutFirst.currentHash,
+        now: Date.now(),
+      }),
+    ).to.equal("revoked");
+    expect(
+      (
+        await rotate(
+          logoutFirst.session,
+          logoutFirst.currentHash,
+          digest("logout-first:next"),
+        )
+      ).outcome,
+    ).to.equal("missing");
+    expect(await sessions.getSession(logoutFirst.session.sid)).to.equal(null);
+    expect(
+      await client.sIsMember(
+        `user:sessions:${logoutFirst.session.publicId}`,
+        logoutFirst.session.sid,
+      ),
+    ).to.equal(false);
+  });
+
+  it("returns bounded outcomes for missing, malformed, and non-object records without mutation", async () => {
+    const publicId = `${testPrefix}invalid-record-user`;
+    const missingSid = crypto.randomUUID();
+    await client.sAdd(`user:sessions:${publicId}`, missingSid);
+
+    expect(
+      await sessions.touchSession({
+        sid: missingSid,
+        publicId,
+        lastSeenAt: Date.now(),
+      }),
+    ).to.equal("missing");
+    expect(
+      await sessions.markSessionEmailVerified({ sid: missingSid, publicId }),
+    ).to.equal("missing");
+    expect(await client.exists(`session:${missingSid}`)).to.equal(0);
+    expect(
+      await client.sIsMember(`user:sessions:${publicId}`, missingSid),
+    ).to.equal(true);
+
+    for (const [label, raw] of [
+      ["malformed", "{not-json"],
+      ["non-object", "42"],
+      ["array", "[]"],
+    ] as const) {
+      const sid = crypto.randomUUID();
+      trackedSessions.set(sid, publicId);
+      await client.setEx(`session:${sid}`, 60, raw);
+      await client.sAdd(`user:sessions:${publicId}`, sid);
+      const shape = {
+        sid,
+        publicId,
+        isEmailVerified: false,
+        refreshTokenHash: digest(`${label}:current`),
+        refreshVersion: 0,
+        createdAt: Date.now(),
+        lastSeenAt: Date.now(),
+        status: "active" as const,
+      };
+
+      expect(
+        (
+          await rotate(shape, shape.refreshTokenHash, digest(`${label}:next`))
+        ).outcome,
+      ).to.equal("invalid_record");
+      expect(
+        await sessions.touchSession({
+          sid,
+          publicId,
+          lastSeenAt: Date.now() + 1_000,
+        }),
+      ).to.equal("invalid_record");
+      expect(
+        await sessions.markSessionEmailVerified({ sid, publicId }),
+      ).to.equal("invalid_record");
+      expect(await client.get(`session:${sid}`)).to.equal(raw);
+      expect(await client.sIsMember(`user:sessions:${publicId}`, sid)).to.equal(
+        true,
+      );
+      await expectRejectionMessage(
+        authSessions.getRefreshSession(`${sid}.presented-secret`),
+        "Session is invalid or expired",
+      );
+    }
+  });
+
+  it("rotates a legacy session without refreshVersion from generation zero", async () => {
+    const sid = crypto.randomUUID();
+    const publicId = `${testPrefix}legacy-user`;
+    const currentHash = digest("legacy:current");
+    const legacy = {
+      sid,
+      publicId,
+      isEmailVerified: false,
+      refreshTokenHash: currentHash,
+      createdAt: Date.now(),
+      lastSeenAt: Date.now(),
+      status: "active" as const,
+    };
+    trackedSessions.set(sid, publicId);
+    await sessions.saveSession(legacy, 60);
+
+    const result = await rotate(
+      { ...legacy, refreshVersion: 0 },
+      currentHash,
+      digest("legacy:next"),
+    );
+
+    expect(result.outcome).to.equal("rotated");
+    const stored = await sessions.getSession<TestSession>(sid);
+    expect(stored?.refreshVersion).to.equal(1);
+    expect(stored?.previousRefreshTokenHash).to.equal(currentHash);
+    expect(await client.sIsMember(`user:sessions:${publicId}`, sid)).to.equal(
+      true,
+    );
+  });
+});

--- a/backend/src/__tests__/services/auth-session.service.test.ts
+++ b/backend/src/__tests__/services/auth-session.service.test.ts
@@ -4,43 +4,44 @@ import sinon from "sinon";
 import crypto from "crypto";
 import { AuthSessionService } from "@/services/auth-session.service";
 import { RedisService } from "@/services/redis.service";
+import { AuthSessionRecord } from "@/types";
 
 describe("AuthSessionService", () => {
 	let authSessionService: AuthSessionService;
 	let getAuthSessionStub: sinon.SinonStub;
 	let saveAuthSessionStub: sinon.SinonStub;
+	let compareAndRotateAuthSessionStub: sinon.SinonStub;
+	let touchAuthSessionStub: sinon.SinonStub;
+	let markAuthSessionEmailVerifiedStub: sinon.SinonStub;
+	let revokeAuthSessionByRefreshTokenStub: sinon.SinonStub;
 	let removeAuthSessionStub: sinon.SinonStub;
 	let removeAuthSessionMembershipStub: sinon.SinonStub;
 	let getUserAuthSessionIdsStub: sinon.SinonStub;
 	let deleteUserAuthSessionsStub: sinon.SinonStub;
-	let getAuthSessionsWithTtlStub: sinon.SinonStub;
-	let getAuthSessionTtlStub: sinon.SinonStub;
-	let updateAuthSessionStub: sinon.SinonStub;
-	let updateAuthSessionsStub: sinon.SinonStub;
 
 	beforeEach(() => {
 		getAuthSessionStub = sinon.stub();
 		saveAuthSessionStub = sinon.stub().resolves();
+		compareAndRotateAuthSessionStub = sinon.stub();
+		touchAuthSessionStub = sinon.stub().resolves("updated");
+		markAuthSessionEmailVerifiedStub = sinon.stub().resolves("updated");
+		revokeAuthSessionByRefreshTokenStub = sinon.stub().resolves("revoked");
 		removeAuthSessionStub = sinon.stub().resolves();
 		removeAuthSessionMembershipStub = sinon.stub().resolves();
 		getUserAuthSessionIdsStub = sinon.stub().resolves([]);
 		deleteUserAuthSessionsStub = sinon.stub().resolves();
-		getAuthSessionsWithTtlStub = sinon.stub().resolves([]);
-		getAuthSessionTtlStub = sinon.stub().resolves(3600);
-		updateAuthSessionStub = sinon.stub().resolves();
-		updateAuthSessionsStub = sinon.stub().resolves();
 
 		const mockRedisService = {
 			getAuthSession: getAuthSessionStub,
 			saveAuthSession: saveAuthSessionStub,
+			compareAndRotateAuthSession: compareAndRotateAuthSessionStub,
+			touchAuthSession: touchAuthSessionStub,
+			markAuthSessionEmailVerified: markAuthSessionEmailVerifiedStub,
+			revokeAuthSessionByRefreshToken: revokeAuthSessionByRefreshTokenStub,
 			removeAuthSession: removeAuthSessionStub,
 			removeAuthSessionMembership: removeAuthSessionMembershipStub,
 			getUserAuthSessionIds: getUserAuthSessionIdsStub,
 			deleteUserAuthSessions: deleteUserAuthSessionsStub,
-			getAuthSessionsWithTtl: getAuthSessionsWithTtlStub,
-			getAuthSessionTtl: getAuthSessionTtlStub,
-			updateAuthSession: updateAuthSessionStub,
-			updateAuthSessions: updateAuthSessionsStub,
 		} as unknown as RedisService;
 
 		authSessionService = new AuthSessionService(mockRedisService);
@@ -68,6 +69,7 @@ describe("AuthSessionService", () => {
 		expect(session.publicId).to.equal("user-public-id");
 		expect(session.isEmailVerified).to.equal(true);
 		expect(session.status).to.equal("active");
+		expect(session.refreshVersion).to.equal(0);
 		expect(session.refreshTokenHash).to.not.equal(refreshToken);
 		expect(saveAuthSessionStub.calledOnce).to.be.true;
 		expect(saveAuthSessionStub.firstCall.args[1]).to.equal(3600);
@@ -81,7 +83,9 @@ describe("AuthSessionService", () => {
 		getAuthSessionStub.resolves({
 			sid,
 			publicId: "user-public-id",
+			isEmailVerified: true,
 			refreshTokenHash,
+			refreshVersion: 0,
 			createdAt: Date.now(),
 			lastSeenAt: Date.now(),
 			status: "active",
@@ -99,7 +103,9 @@ describe("AuthSessionService", () => {
 		getAuthSessionStub.onFirstCall().resolves({
 			sid,
 			publicId: "user-public-id",
+			isEmailVerified: true,
 			refreshTokenHash: crypto.createHash("sha256").update("different-token", "utf8").digest("hex"),
+			refreshVersion: 0,
 			createdAt: Date.now(),
 			lastSeenAt: Date.now(),
 			status: "active",
@@ -107,7 +113,9 @@ describe("AuthSessionService", () => {
 		getAuthSessionStub.onSecondCall().resolves({
 			sid,
 			publicId: "user-public-id",
+			isEmailVerified: true,
 			refreshTokenHash: crypto.createHash("sha256").update("different-token", "utf8").digest("hex"),
+			refreshVersion: 0,
 			createdAt: Date.now(),
 			lastSeenAt: Date.now(),
 			status: "active",
@@ -125,7 +133,9 @@ describe("AuthSessionService", () => {
 		getAuthSessionStub.resolves({
 			sid,
 			publicId: "user-public-id",
+			isEmailVerified: true,
 			refreshTokenHash: crypto.createHash("sha256").update(currentRefreshToken, "utf8").digest("hex"),
+			refreshVersion: 1,
 			previousRefreshTokenHash: crypto.createHash("sha256").update(previousRefreshToken, "utf8").digest("hex"),
 			previousRefreshTokenGraceUntil: Date.now() + 60_000,
 			createdAt: Date.now(),
@@ -145,32 +155,132 @@ describe("AuthSessionService", () => {
 		const currentRefreshToken = `${sid}.current-refresh-secret`;
 		const nextRefreshToken = `${sid}.next-refresh-secret`;
 
-		getAuthSessionStub.resolves({
+		const session = {
 			sid,
 			publicId: "user-public-id",
 			refreshTokenHash: crypto.createHash("sha256").update(currentRefreshToken, "utf8").digest("hex"),
+			refreshVersion: 1,
 			previousRefreshTokenHash: crypto.createHash("sha256").update(priorRefreshToken, "utf8").digest("hex"),
 			previousRefreshTokenGraceUntil: Date.now() + 60_000,
 			createdAt: Date.now(),
 			lastSeenAt: Date.now(),
 			status: "active",
+		} as const;
+		compareAndRotateAuthSessionStub.resolves({
+			outcome: "stale_previous",
+			session: null,
 		});
 
-		await expect(authSessionService.rotateRefreshToken(sid, priorRefreshToken, nextRefreshToken, 3600)).to.be.rejectedWith(
+		await expect(authSessionService.rotateRefreshToken(session as AuthSessionRecord, priorRefreshToken, nextRefreshToken, 3600)).to.be.rejectedWith(
 			"Refresh token already rotated",
 		);
-		expect(saveAuthSessionStub.called).to.be.false;
+		expect(compareAndRotateAuthSessionStub.calledOnce).to.be.true;
 		expect(removeAuthSessionStub.called).to.be.false;
 	});
+
+	it("rejects a refresh record whose embedded SID differs from the token SID", async () => {
+		const sid = "3f7c90af-22a8-4a48-8e03-3ea6f865b59f";
+		getAuthSessionStub.resolves({
+			sid: "4f7c90af-22a8-4a48-8e03-3ea6f865b59f",
+			publicId: "user-public-id",
+			isEmailVerified: true,
+			refreshTokenHash: crypto.createHash("sha256").update("hash-source", "utf8").digest("hex"),
+			refreshVersion: 0,
+			createdAt: Date.now(),
+			lastSeenAt: Date.now(),
+			status: "active",
+		});
+
+		await expect(
+			authSessionService.getRefreshSession(`${sid}.refresh-secret`),
+		).to.be.rejectedWith("Session is invalid or expired");
+		expect(removeAuthSessionStub.called).to.equal(false);
+		expect(removeAuthSessionMembershipStub.called).to.equal(false);
+	});
+
+	it("returns the atomically rotated session", async () => {
+		const sid = "3f7c90af-22a8-4a48-8e03-3ea6f865b59f";
+		const currentRefreshToken = `${sid}.current-refresh-secret`;
+		const nextRefreshToken = `${sid}.next-refresh-secret`;
+		const session = {
+			sid,
+			publicId: "user-public-id",
+			isEmailVerified: true,
+			refreshTokenHash: crypto.createHash("sha256").update(currentRefreshToken, "utf8").digest("hex"),
+			refreshVersion: 0,
+			createdAt: Date.now(),
+			lastSeenAt: Date.now(),
+			status: "active",
+		} as const;
+		const rotated = {
+			...session,
+			refreshTokenHash: crypto.createHash("sha256").update(nextRefreshToken, "utf8").digest("hex"),
+			previousRefreshTokenHash: session.refreshTokenHash,
+			refreshVersion: 1,
+		};
+		compareAndRotateAuthSessionStub.resolves({
+			outcome: "rotated",
+			session: rotated,
+		});
+
+		const result = await authSessionService.rotateRefreshToken(
+			session as AuthSessionRecord,
+			currentRefreshToken,
+			nextRefreshToken,
+			3600,
+		);
+
+		expect(result).to.equal(rotated);
+		const input = compareAndRotateAuthSessionStub.firstCall.args[0];
+		expect(input.sid).to.equal(sid);
+		expect(input.expectedRefreshVersion).to.equal(0);
+		expect(input.presentedRefreshTokenHash).to.not.equal(currentRefreshToken);
+		expect(input.nextRefreshTokenHash).to.not.equal(nextRefreshToken);
+	});
+
+	for (const [outcome, message] of [
+		["missing", "Session is invalid or expired"],
+		["revoked", "Session is invalid or expired"],
+		["identity_mismatch", "Session is invalid or expired"],
+		["invalid_record", "Session is invalid or expired"],
+		["mismatch", "Refresh token reuse detected"],
+		["version_conflict", "Refresh session state changed"],
+	] as const) {
+		it(`maps ${outcome} to a deterministic authentication error`, async () => {
+			const sid = "3f7c90af-22a8-4a48-8e03-3ea6f865b59f";
+			const refreshToken = `${sid}.current-refresh-secret`;
+			const session = {
+				sid,
+				publicId: "user-public-id",
+				isEmailVerified: true,
+				refreshTokenHash: crypto.createHash("sha256").update(refreshToken, "utf8").digest("hex"),
+				refreshVersion: 0,
+				createdAt: Date.now(),
+				lastSeenAt: Date.now(),
+				status: "active",
+			} as const;
+			compareAndRotateAuthSessionStub.resolves({ outcome, session: null });
+
+			await expect(
+				authSessionService.rotateRefreshToken(
+					session as AuthSessionRecord,
+					refreshToken,
+					`${sid}.next-refresh-secret`,
+					3600,
+				),
+			).to.be.rejectedWith(message);
+		});
+	}
 
 	it("updates lastSeenAt during access-session validation when touch interval has elapsed", async () => {
 		const sid = "3f7c90af-22a8-4a48-8e03-3ea6f865b59f";
 		const previousSeen = Date.now() - 120_000;
+		const createdAt = Date.now() - 300_000;
 		getAuthSessionStub.resolves({
 			sid,
 			publicId: "user-public-id",
 			refreshTokenHash: crypto.createHash("sha256").update(`${sid}.refresh-secret`, "utf8").digest("hex"),
-			createdAt: Date.now() - 300_000,
+			createdAt,
 			lastSeenAt: previousSeen,
 			status: "active",
 		});
@@ -178,11 +288,28 @@ describe("AuthSessionService", () => {
 		const session = await authSessionService.assertAccessSession(sid, "user-public-id");
 
 		expect(session.sid).to.equal(sid);
-		expect(getAuthSessionTtlStub.calledOnceWith(sid)).to.be.true;
-		expect(updateAuthSessionStub.calledOnce).to.be.true;
-		expect(updateAuthSessionStub.firstCall.args[0]).to.equal(sid);
-		expect(updateAuthSessionStub.firstCall.args[2]).to.equal(3600);
-		expect(updateAuthSessionStub.firstCall.args[1].lastSeenAt).to.be.greaterThan(previousSeen);
+		expect(touchAuthSessionStub.calledOnce).to.be.true;
+		const input = touchAuthSessionStub.firstCall.args[0];
+		expect(input.sid).to.equal(sid);
+		expect(input.publicId).to.equal("user-public-id");
+		expect(input.lastSeenAt).to.be.greaterThan(previousSeen);
+	});
+
+	it("rejects access when the atomic touch observes a deleted session", async () => {
+		const sid = "3f7c90af-22a8-4a48-8e03-3ea6f865b59f";
+		getAuthSessionStub.resolves({
+			sid,
+			publicId: "user-public-id",
+			refreshTokenHash: crypto.createHash("sha256").update(`${sid}.refresh-secret`, "utf8").digest("hex"),
+			createdAt: Date.now() - 300_000,
+			lastSeenAt: Date.now() - 120_000,
+			status: "active",
+		});
+		touchAuthSessionStub.resolves("missing");
+
+		await expect(authSessionService.assertAccessSession(sid, "user-public-id")).to.be.rejectedWith(
+			"Session is invalid or expired",
+		);
 	});
 
 	it("removes stale user-session index entry when access-session key is missing", async () => {
@@ -203,57 +330,58 @@ describe("AuthSessionService", () => {
 		expect(deleteUserAuthSessionsStub.calledOnceWith("user-public-id", ["session-a", "session-b"])).to.equal(true);
 	});
 
+	it("atomically revokes the session addressed by a refresh token", async () => {
+		const sid = "3f7c90af-22a8-4a48-8e03-3ea6f865b59f";
+		const refreshToken = `${sid}.refresh-secret`;
+
+		await authSessionService.revokeSessionByRefreshToken(refreshToken);
+
+		expect(revokeAuthSessionByRefreshTokenStub.calledOnce).to.equal(true);
+		const input = revokeAuthSessionByRefreshTokenStub.firstCall.args[0];
+		expect(input.sid).to.equal(sid);
+		expect(input.presentedRefreshTokenHash).to.not.equal(refreshToken);
+		expect(input.now).to.be.a("number");
+	});
+
+	it("maps refresh-token revocation mismatch to token reuse", async () => {
+		const sid = "3f7c90af-22a8-4a48-8e03-3ea6f865b59f";
+		revokeAuthSessionByRefreshTokenStub.resolves("mismatch");
+
+		await expect(
+			authSessionService.revokeSessionByRefreshToken(`${sid}.refresh-secret`),
+		).to.be.rejectedWith("Refresh token reuse detected");
+	});
+
 	it("marks active sessions as email verified", async () => {
 		const sessionA = "11111111-1111-4111-8111-111111111111";
 		const sessionB = "22222222-2222-4222-8222-222222222222";
 		const staleSession = "33333333-3333-4333-8333-333333333333";
 		getUserAuthSessionIdsStub.resolves([sessionA, sessionB, staleSession]);
-		getAuthSessionsWithTtlStub.resolves([
-			{
-				sid: sessionA,
-				session: {
-				sid: sessionA,
-				publicId: "user-public-id",
-				isEmailVerified: false,
-				refreshTokenHash: crypto.createHash("sha256").update("refresh-a", "utf8").digest("hex"),
-				createdAt: Date.now(),
-				lastSeenAt: Date.now(),
-				status: "active",
-				},
-				ttlSeconds: 3600,
-			},
-			{
-				sid: sessionB,
-				session: {
-				sid: sessionB,
-				publicId: "user-public-id",
-				isEmailVerified: false,
-				refreshTokenHash: crypto.createHash("sha256").update("refresh-b", "utf8").digest("hex"),
-				createdAt: Date.now(),
-				lastSeenAt: Date.now(),
-				status: "active",
-				},
-				ttlSeconds: 1800,
-			},
-			{
-				sid: staleSession,
-				session: null,
-				ttlSeconds: -2,
-			},
-		]);
 
 		await authSessionService.markUserEmailVerified("user-public-id");
 
-		expect(updateAuthSessionsStub.calledOnce).to.equal(true);
-		const [publicId, updates, staleSessionIds] = updateAuthSessionsStub.firstCall.args;
-		expect(publicId).to.equal("user-public-id");
-		expect(staleSessionIds).to.deep.equal([staleSession]);
-		expect(updates).to.have.length(2);
-		expect(updates[0].sid).to.equal(sessionA);
-		expect(updates[0].ttlSeconds).to.equal(3600);
-		expect(updates[0].session.isEmailVerified).to.equal(true);
-		expect(updates[1].sid).to.equal(sessionB);
-		expect(updates[1].ttlSeconds).to.equal(1800);
-		expect(updates[1].session.isEmailVerified).to.equal(true);
+		expect(markAuthSessionEmailVerifiedStub.callCount).to.equal(3);
+		expect(markAuthSessionEmailVerifiedStub.getCalls().map((call) => call.args[0])).to.deep.equal([
+			{ sid: sessionA, publicId: "user-public-id" },
+			{ sid: sessionB, publicId: "user-public-id" },
+			{ sid: staleSession, publicId: "user-public-id" },
+		]);
+	});
+
+	it("cleans only missing email-verification memberships", async () => {
+		const activeSession = "11111111-1111-4111-8111-111111111111";
+		const missingSession = "22222222-2222-4222-8222-222222222222";
+		getUserAuthSessionIdsStub.resolves([activeSession, missingSession]);
+		markAuthSessionEmailVerifiedStub.onFirstCall().resolves("updated");
+		markAuthSessionEmailVerifiedStub.onSecondCall().resolves("missing");
+
+		await authSessionService.markUserEmailVerified("user-public-id");
+
+		expect(
+			removeAuthSessionMembershipStub.calledOnceWith(
+				"user-public-id",
+				missingSession,
+			),
+		).to.equal(true);
 	});
 });

--- a/backend/src/services/auth-session.service.ts
+++ b/backend/src/services/auth-session.service.ts
@@ -71,6 +71,7 @@ export class AuthSessionService {
       refreshTokenHash: asRefreshTokenHash(
         this.hashRefreshToken(input.refreshToken),
       ),
+      refreshVersion: 0,
       createdAt: now,
       lastSeenAt: now,
       ip: input.ip,
@@ -111,7 +112,11 @@ export class AuthSessionService {
       await this.redisService.removeAuthSessionMembership(publicId, sid);
       throw Errors.authentication("Session is invalid or expired");
     }
-    if (session.status !== "active" || session.publicId !== publicId) {
+    if (
+      session.sid !== sid ||
+      session.status !== "active" ||
+      session.publicId !== publicId
+    ) {
       throw Errors.authentication("Session is invalid or expired");
     }
     await this.touchSessionOnAccess(session);
@@ -126,15 +131,7 @@ export class AuthSessionService {
    * - Returns session only for valid token and revokes session on suspicious reuse
    */
   async validateRefreshToken(refreshToken: string): Promise<AuthSessionRecord> {
-    const sid = this.extractSessionIdFromRefreshToken(refreshToken);
-    if (!sid) {
-      throw Errors.authentication("Invalid refresh token");
-    }
-
-    const session = await this.getSession(sid);
-    if (!session || session.status !== "active") {
-      throw Errors.authentication("Session is invalid or expired");
-    }
+    const session = await this.getRefreshSession(refreshToken);
 
     const presentedHash = this.hashRefreshToken(refreshToken);
     const matchState = this.classifyRefreshTokenMatch(session, presentedHash);
@@ -142,8 +139,34 @@ export class AuthSessionService {
       throw Errors.authentication("Refresh token already rotated");
     }
     if (matchState !== "current") {
-      await this.revokeSession(sid);
+      await this.revokeSession(session.sid);
       throw Errors.authentication("Refresh token reuse detected");
+    }
+
+    return session;
+  }
+
+  /**
+   * Loads the active session addressed by a refresh token without accepting its hash
+   *
+   * - Refresh orchestration needs user context before minting a successor
+   * - Hash acceptance is deferred to the atomic Redis compare-and-rotate operation
+   */
+  async getRefreshSession(refreshToken: string): Promise<AuthSessionRecord> {
+    const sid = this.extractSessionIdFromRefreshToken(refreshToken);
+    if (!sid) {
+      throw Errors.authentication("Invalid refresh token");
+    }
+
+    let session: unknown;
+    try {
+      session = await this.redisService.getAuthSession<unknown>(sid);
+    } catch {
+      throw Errors.authentication("Session is invalid or expired");
+    }
+
+    if (!this.isExpectedActiveRefreshSession(session, sid)) {
+      throw Errors.authentication("Session is invalid or expired");
     }
 
     return session;
@@ -157,44 +180,49 @@ export class AuthSessionService {
    * - Stores next token hash, tracks previous hash grace period, and refreshes session metadata
    */
   async rotateRefreshToken(
-    sid: string,
+    current: AuthSessionRecord,
     presentedRefreshToken: string,
     nextRefreshToken: string,
     ttlSeconds: number,
     context?: SessionContext,
   ): Promise<AuthSessionRecord> {
-    const current = await this.getSession(sid);
-    if (!current || current.status !== "active") {
-      throw Errors.authentication("Session is invalid or expired");
-    }
-
-    const presentedHash = this.hashRefreshToken(presentedRefreshToken);
-    const matchState = this.classifyRefreshTokenMatch(current, presentedHash);
-    if (matchState === "recently_rotated") {
-      throw Errors.authentication("Refresh token already rotated");
-    }
-    if (matchState !== "current") {
-      await this.revokeSession(sid);
-      throw Errors.authentication("Refresh token reuse detected");
-    }
-
     const now = Date.now();
     const normalizedTtl = this.normalizeTtlSeconds(ttlSeconds);
-    const next: AuthSessionRecord = {
-      ...current,
-      refreshTokenHash: asRefreshTokenHash(
-        this.hashRefreshToken(nextRefreshToken),
-      ),
-      previousRefreshTokenHash: current.refreshTokenHash,
-      previousRefreshTokenGraceUntil: now + this.getRefreshRotationGraceMs(),
-      lastSeenAt: now,
-      ip: context?.ip ?? current.ip,
-      userAgent: context?.userAgent ?? current.userAgent,
-    };
+    const result =
+      await this.redisService.compareAndRotateAuthSession<AuthSessionRecord>({
+        sid: current.sid,
+        publicId: current.publicId,
+        presentedRefreshTokenHash: this.hashRefreshToken(
+          presentedRefreshToken,
+        ),
+        nextRefreshTokenHash: this.hashRefreshToken(nextRefreshToken),
+        expectedRefreshVersion: current.refreshVersion ?? 0,
+        now,
+        previousRefreshTokenGraceUntil:
+          now + this.getRefreshRotationGraceMs(),
+        ttlSeconds: normalizedTtl,
+        ip: context?.ip,
+        userAgent: context?.userAgent,
+      });
 
-    await this.redisService.saveAuthSession(next, normalizedTtl);
-
-    return next;
+    switch (result.outcome) {
+      case "rotated":
+        if (!result.session) {
+          throw Errors.internal("Atomic refresh rotation returned no session");
+        }
+        return result.session;
+      case "stale_previous":
+        throw Errors.authentication("Refresh token already rotated");
+      case "missing":
+      case "revoked":
+      case "identity_mismatch":
+      case "invalid_record":
+        throw Errors.authentication("Session is invalid or expired");
+      case "mismatch":
+        throw Errors.authentication("Refresh token reuse detected");
+      case "version_conflict":
+        throw Errors.authentication("Refresh session state changed");
+    }
   }
 
   /**
@@ -204,10 +232,43 @@ export class AuthSessionService {
    * - Clears both the session key and the user-session index entry to avoid dangling references
    */
   async revokeSession(sid: string): Promise<void> {
-    const session = await this.getSession(sid);
+    let session: AuthSessionRecord | null;
+    try {
+      session = await this.getSession(sid);
+    } catch {
+      throw Errors.authentication("Session is invalid or expired");
+    }
     if (!session) return;
+    if (session.sid !== sid || typeof session.publicId !== "string") {
+      throw Errors.authentication("Session is invalid or expired");
+    }
 
     await this.redisService.removeAuthSession(sid, session.publicId);
+  }
+
+  async revokeSessionByRefreshToken(refreshToken: string): Promise<void> {
+    const sid = this.extractSessionIdFromRefreshToken(refreshToken);
+    if (!sid) {
+      throw Errors.authentication("Invalid refresh token");
+    }
+
+    const outcome = await this.redisService.revokeAuthSessionByRefreshToken({
+      sid,
+      presentedRefreshTokenHash: this.hashRefreshToken(refreshToken),
+      now: Date.now(),
+    });
+
+    switch (outcome) {
+      case "revoked":
+        return;
+      case "mismatch":
+        throw Errors.authentication("Refresh token reuse detected");
+      case "missing":
+      case "inactive":
+      case "identity_mismatch":
+      case "invalid_record":
+        throw Errors.authentication("Session is invalid or expired");
+    }
   }
 
   /**
@@ -226,41 +287,21 @@ export class AuthSessionService {
     const sessionIds = await this.redisService.getUserAuthSessionIds(publicId);
     if (sessionIds.length === 0) return;
 
-    const staleSessionIds: string[] = [];
-    const sessionsToUpdate = (
-      await this.redisService.getAuthSessionsWithTtl<AuthSessionRecord>(
-        sessionIds,
-      )
-    )
-      .map((entry) => {
-        if (!entry.session || entry.ttlSeconds <= 0) {
-          staleSessionIds.push(entry.sid);
-          return null;
-        }
-
-        return {
-          ...entry,
-          session: {
-            ...entry.session,
-            isEmailVerified: true,
-          },
-        };
-      })
-      .filter(
-        (
-          entry,
-        ): entry is {
-          sid: string;
-          session: AuthSessionRecord;
-          ttlSeconds: number;
-        } => entry !== null,
-      );
-
-    await this.redisService.updateAuthSessions(
-      publicId,
-      sessionsToUpdate,
-      staleSessionIds,
+    const outcomes = await Promise.all(
+      sessionIds.map((sid) =>
+        this.redisService.markAuthSessionEmailVerified({ sid, publicId }),
+      ),
     );
+
+    for (let index = 0; index < outcomes.length; index += 1) {
+      const outcome = outcomes[index];
+      const sid = sessionIds[index];
+      if (outcome === "missing") {
+        await this.redisService.removeAuthSessionMembership(publicId, sid);
+      } else if (outcome !== "updated") {
+        throw Errors.internal("Session metadata update failed");
+      }
+    }
   }
 
   /**
@@ -325,6 +366,62 @@ export class AuthSessionService {
     return "unknown";
   }
 
+  private isExpectedActiveRefreshSession(
+    value: unknown,
+    expectedSid: string,
+  ): value is AuthSessionRecord {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+
+    const session = value as Record<string, unknown>;
+    if (
+      session.sid !== expectedSid ||
+      typeof session.publicId !== "string" ||
+      session.publicId.length === 0 ||
+      typeof session.isEmailVerified !== "boolean" ||
+      typeof session.refreshTokenHash !== "string" ||
+      !SHA256_HEX_REGEX.test(session.refreshTokenHash) ||
+      typeof session.createdAt !== "number" ||
+      !Number.isFinite(session.createdAt) ||
+      typeof session.lastSeenAt !== "number" ||
+      !Number.isFinite(session.lastSeenAt) ||
+      session.status !== "active"
+    ) {
+      return false;
+    }
+
+    const refreshVersion = session.refreshVersion;
+    if (
+      refreshVersion !== undefined &&
+      (typeof refreshVersion !== "number" ||
+        !Number.isInteger(refreshVersion) ||
+        refreshVersion < 0)
+    ) {
+      return false;
+    }
+
+    const previousHash = session.previousRefreshTokenHash;
+    const previousGraceUntil = session.previousRefreshTokenGraceUntil;
+    if (
+      previousHash !== undefined &&
+      (typeof previousHash !== "string" ||
+        !SHA256_HEX_REGEX.test(previousHash))
+    ) {
+      return false;
+    }
+
+    if (
+      previousGraceUntil !== undefined &&
+      (typeof previousGraceUntil !== "number" ||
+        !Number.isFinite(previousGraceUntil))
+    ) {
+      return false;
+    }
+
+    return (previousHash === undefined) === (previousGraceUntil === undefined);
+  }
+
   /**
    * Updates `lastSeenAt` for active usage throttled by a configurable interval
    *
@@ -342,28 +439,19 @@ export class AuthSessionService {
       return;
     }
 
-    const ttlSeconds = await this.redisService.getAuthSessionTtl(session.sid);
-    if (ttlSeconds <= 0) {
+    const outcome = await this.redisService.touchAuthSession({
+      sid: session.sid,
+      publicId: session.publicId,
+      lastSeenAt: now,
+    });
+    if (outcome === "updated") return;
+    if (outcome === "missing") {
       await this.redisService.removeAuthSessionMembership(
         session.publicId,
         session.sid,
       );
-      throw Errors.authentication("Session is invalid or expired");
     }
-
-    const touchedSession: AuthSessionRecord = {
-      ...session,
-      lastSeenAt: now,
-    };
-    await this.redisService.updateAuthSession(
-      session.sid,
-      touchedSession,
-      ttlSeconds,
-    );
-  }
-
-  private sessionKey(sid: string): string {
-    return `session:${sid}`;
+    throw Errors.authentication("Session is invalid or expired");
   }
 
   /**

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -119,8 +119,9 @@ export class AuthService {
     refreshToken: string,
     context: AuthSessionContext = {},
   ): Promise<AuthenticatedSessionResult> {
-    const session =
-      await this.authSessionService.validateRefreshToken(refreshToken);
+    const session = await this.authSessionService.getRefreshSession(
+      refreshToken,
+    );
     const user = await this.userReadRepository.findByPublicId(session.publicId);
     if (!user) {
       await this.authSessionService.revokeSession(session.sid);
@@ -138,7 +139,7 @@ export class AuthService {
       session.sid,
     );
     await this.authSessionService.rotateRefreshToken(
-      session.sid,
+      session,
       refreshToken,
       nextRefreshToken,
       this.getRefreshTokenTtlSeconds(),
@@ -159,13 +160,11 @@ export class AuthService {
 
   /**
    * Revokes one session using a refresh token
-   * - validates token first to get trusted session context
-   * - removes only the matching sid
+   * - atomically validates the token against current session state
+   * - removes only the matching sid and membership entry
    */
   async revokeSessionByRefreshToken(refreshToken: string): Promise<void> {
-    const session =
-      await this.authSessionService.validateRefreshToken(refreshToken);
-    await this.authSessionService.revokeSession(session.sid);
+    await this.authSessionService.revokeSessionByRefreshToken(refreshToken);
   }
 
   /**

--- a/backend/src/services/redis.service.ts
+++ b/backend/src/services/redis.service.ts
@@ -7,8 +7,15 @@ import { RedisNotificationModule } from "./redis/redis-notification.module";
 import { RedisFeedModule } from "./redis/redis-feed.module";
 import { RedisStreamModule } from "./redis/redis-stream.module";
 import {
+  CompareAndRotateSessionInput,
+  CompareAndRotateSessionResult,
+  PatchSessionMetadataInput,
   RedisSessionModule,
+  RefreshSessionRevocationOutcome,
+  RevokeRefreshSessionInput,
+  SessionMetadataPatchOutcome,
   SessionWithTtl,
+  TouchSessionInput,
 } from "./redis/redis-session.module";
 import { RedisFeedType } from "@/utils/cache/CacheKeyBuilder";
 import { TOKENS } from "@/types/tokens";
@@ -250,12 +257,28 @@ export class RedisService {
     return this.sessionModule.saveSession(session, ttlSeconds);
   }
 
-  async updateAuthSession<T>(
-    sid: string,
-    session: T,
-    ttlSeconds: number,
-  ): Promise<void> {
-    return this.sessionModule.updateSession(sid, session, ttlSeconds);
+  async compareAndRotateAuthSession<T>(
+    input: CompareAndRotateSessionInput,
+  ): Promise<CompareAndRotateSessionResult<T>> {
+    return this.sessionModule.compareAndRotateSession<T>(input);
+  }
+
+  async touchAuthSession(
+    input: TouchSessionInput,
+  ): Promise<SessionMetadataPatchOutcome> {
+    return this.sessionModule.touchSession(input);
+  }
+
+  async markAuthSessionEmailVerified(
+    input: PatchSessionMetadataInput,
+  ): Promise<SessionMetadataPatchOutcome> {
+    return this.sessionModule.markSessionEmailVerified(input);
+  }
+
+  async revokeAuthSessionByRefreshToken(
+    input: RevokeRefreshSessionInput,
+  ): Promise<RefreshSessionRevocationOutcome> {
+    return this.sessionModule.revokeRefreshSession(input);
   }
 
   async removeAuthSession(sid: string, publicId: string): Promise<void> {
@@ -288,18 +311,6 @@ export class RedisService {
     sessionIds: string[],
   ): Promise<Array<SessionWithTtl<T>>> {
     return this.sessionModule.getSessionsWithTtl<T>(sessionIds);
-  }
-
-  async updateAuthSessions<T>(
-    publicId: string,
-    updates: Array<SessionWithTtl<T>>,
-    staleSessionIds: string[] = [],
-  ): Promise<void> {
-    return this.sessionModule.updateSessions(
-      publicId,
-      updates,
-      staleSessionIds,
-    );
   }
 
   async addToFeed(

--- a/backend/src/services/redis/redis-session.module.ts
+++ b/backend/src/services/redis/redis-session.module.ts
@@ -5,6 +5,234 @@ type SessionRecord = {
   publicId: string;
 };
 
+export type RefreshRotationOutcome =
+  | "rotated"
+  | "stale_previous"
+  | "missing"
+  | "revoked"
+  | "mismatch"
+  | "identity_mismatch"
+  | "invalid_record"
+  | "version_conflict";
+
+export interface CompareAndRotateSessionInput {
+  sid: string;
+  publicId: string;
+  presentedRefreshTokenHash: string;
+  nextRefreshTokenHash: string;
+  expectedRefreshVersion: number;
+  now: number;
+  previousRefreshTokenGraceUntil: number;
+  ttlSeconds: number;
+  ip?: string;
+  userAgent?: string;
+}
+
+export interface CompareAndRotateSessionResult<T> {
+  outcome: RefreshRotationOutcome;
+  session: T | null;
+}
+
+export type SessionMetadataPatchOutcome =
+  | "updated"
+  | "missing"
+  | "identity_mismatch"
+  | "invalid_record";
+
+export interface PatchSessionMetadataInput {
+  sid: string;
+  publicId: string;
+}
+
+export interface TouchSessionInput extends PatchSessionMetadataInput {
+  lastSeenAt: number;
+}
+
+export type RefreshSessionRevocationOutcome =
+  | "revoked"
+  | "missing"
+  | "inactive"
+  | "mismatch"
+  | "identity_mismatch"
+  | "invalid_record";
+
+export interface RevokeRefreshSessionInput {
+  sid: string;
+  presentedRefreshTokenHash: string;
+  now: number;
+}
+
+const COMPARE_AND_ROTATE_SESSION_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  redis.call("SREM", KEYS[2], ARGV[9])
+  return {"missing", ""}
+end
+
+local decoded, session = pcall(cjson.decode, raw)
+if not decoded or type(session) ~= "table" then
+  return {"invalid_record", ""}
+end
+
+if type(session.sid) ~= "string" or type(session.publicId) ~= "string" or
+   type(session.refreshTokenHash) ~= "string" or type(session.status) ~= "string" then
+  return {"invalid_record", ""}
+end
+
+if session.sid ~= ARGV[1] or session.publicId ~= ARGV[2] then
+  return {"identity_mismatch", ""}
+end
+
+if session.status ~= "active" then
+  return {"revoked", ""}
+end
+
+local presentedHash = ARGV[3]
+local currentHash = session.refreshTokenHash
+local previousHash = session.previousRefreshTokenHash
+local now = tonumber(ARGV[6])
+local graceUntil = tonumber(session.previousRefreshTokenGraceUntil or 0)
+
+if previousHash == presentedHash then
+  if graceUntil >= now then
+    return {"stale_previous", ""}
+  end
+
+  redis.call("DEL", KEYS[1])
+  redis.call("SREM", KEYS[2], ARGV[9])
+  return {"mismatch", ""}
+end
+
+if currentHash ~= presentedHash then
+  redis.call("DEL", KEYS[1])
+  redis.call("SREM", KEYS[2], ARGV[9])
+  return {"mismatch", ""}
+end
+
+local currentVersion = tonumber(session.refreshVersion or 0)
+local expectedVersion = tonumber(ARGV[5])
+if not currentVersion or currentVersion ~= expectedVersion then
+  return {"version_conflict", ""}
+end
+
+session.previousRefreshTokenHash = currentHash
+session.previousRefreshTokenGraceUntil = tonumber(ARGV[7])
+session.refreshTokenHash = ARGV[4]
+session.refreshVersion = currentVersion + 1
+local currentLastSeenAt = tonumber(session.lastSeenAt or 0) or 0
+if now > currentLastSeenAt then
+  session.lastSeenAt = now
+end
+if ARGV[10] == "1" then
+  session.ip = ARGV[11]
+end
+if ARGV[12] == "1" then
+  session.userAgent = ARGV[13]
+end
+
+local encoded = cjson.encode(session)
+local ttlSeconds = tonumber(ARGV[8])
+redis.call("SET", KEYS[1], encoded, "EX", ttlSeconds)
+redis.call("SADD", KEYS[2], ARGV[9])
+redis.call("EXPIRE", KEYS[2], ttlSeconds, "NX")
+redis.call("EXPIRE", KEYS[2], ttlSeconds, "GT")
+return {"rotated", encoded}
+`;
+
+const TOUCH_SESSION_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  return "missing"
+end
+
+local decoded, session = pcall(cjson.decode, raw)
+if not decoded or type(session) ~= "table" or
+   type(session.sid) ~= "string" or type(session.publicId) ~= "string" or
+   type(session.lastSeenAt) ~= "number" then
+  return "invalid_record"
+end
+
+if session.sid ~= ARGV[1] or session.publicId ~= ARGV[2] then
+  return "identity_mismatch"
+end
+
+local proposedLastSeenAt = tonumber(ARGV[3])
+if not proposedLastSeenAt then
+  return "invalid_record"
+end
+
+if proposedLastSeenAt > session.lastSeenAt then
+  session.lastSeenAt = proposedLastSeenAt
+  redis.call("SET", KEYS[1], cjson.encode(session), "KEEPTTL")
+end
+
+return "updated"
+`;
+
+const MARK_SESSION_EMAIL_VERIFIED_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  return "missing"
+end
+
+local decoded, session = pcall(cjson.decode, raw)
+if not decoded or type(session) ~= "table" or
+   type(session.sid) ~= "string" or type(session.publicId) ~= "string" or
+   type(session.isEmailVerified) ~= "boolean" then
+  return "invalid_record"
+end
+
+if session.sid ~= ARGV[1] or session.publicId ~= ARGV[2] then
+  return "identity_mismatch"
+end
+
+if not session.isEmailVerified then
+  session.isEmailVerified = true
+  redis.call("SET", KEYS[1], cjson.encode(session), "KEEPTTL")
+end
+
+return "updated"
+`;
+
+const REVOKE_REFRESH_SESSION_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  return "missing"
+end
+
+local decoded, session = pcall(cjson.decode, raw)
+if not decoded or type(session) ~= "table" or
+   type(session.sid) ~= "string" or type(session.publicId) ~= "string" or
+   type(session.refreshTokenHash) ~= "string" or type(session.status) ~= "string" then
+  return "invalid_record"
+end
+
+if session.sid ~= ARGV[1] then
+  return "identity_mismatch"
+end
+
+if session.status ~= "active" then
+  return "inactive"
+end
+
+local presentedHash = ARGV[2]
+local now = tonumber(ARGV[3])
+local currentMatches = session.refreshTokenHash == presentedHash
+local previousMatches = session.previousRefreshTokenHash == presentedHash and
+  tonumber(session.previousRefreshTokenGraceUntil or 0) >= now
+
+local membershipKey = "user:sessions:" .. session.publicId
+if currentMatches or previousMatches then
+  redis.call("DEL", KEYS[1])
+  redis.call("SREM", membershipKey, ARGV[1])
+  return "revoked"
+end
+
+redis.call("DEL", KEYS[1])
+redis.call("SREM", membershipKey, ARGV[1])
+return "mismatch"
+`;
+
 export interface SessionWithTtl<T> {
   sid: string;
   session: T | null;
@@ -37,16 +265,67 @@ export class RedisSessionModule {
     await pipeline.exec();
   }
 
-  async updateSession<T>(
-    sid: string,
-    session: T,
-    ttlSeconds: number,
-  ): Promise<void> {
-    await this.client.setEx(
-      this.sessionKey(sid),
-      ttlSeconds,
-      JSON.stringify(session),
-    );
+  async compareAndRotateSession<T>(
+    input: CompareAndRotateSessionInput,
+  ): Promise<CompareAndRotateSessionResult<T>> {
+    const result = (await this.client.eval(COMPARE_AND_ROTATE_SESSION_SCRIPT, {
+      keys: [
+        this.sessionKey(input.sid),
+        this.userSessionsKey(input.publicId),
+      ],
+      arguments: [
+        input.sid,
+        input.publicId,
+        input.presentedRefreshTokenHash,
+        input.nextRefreshTokenHash,
+        String(input.expectedRefreshVersion),
+        String(input.now),
+        String(input.previousRefreshTokenGraceUntil),
+        String(input.ttlSeconds),
+        input.sid,
+        input.ip === undefined ? "0" : "1",
+        input.ip ?? "",
+        input.userAgent === undefined ? "0" : "1",
+        input.userAgent ?? "",
+      ],
+    })) as [RefreshRotationOutcome, string];
+
+    const [outcome, rawSession] = result;
+    return {
+      outcome,
+      session: rawSession ? (JSON.parse(rawSession) as T) : null,
+    };
+  }
+
+  async touchSession(
+    input: TouchSessionInput,
+  ): Promise<SessionMetadataPatchOutcome> {
+    return this.client.eval(TOUCH_SESSION_SCRIPT, {
+      keys: [this.sessionKey(input.sid)],
+      arguments: [input.sid, input.publicId, String(input.lastSeenAt)],
+    }) as Promise<SessionMetadataPatchOutcome>;
+  }
+
+  async markSessionEmailVerified(
+    input: PatchSessionMetadataInput,
+  ): Promise<SessionMetadataPatchOutcome> {
+    return this.client.eval(MARK_SESSION_EMAIL_VERIFIED_SCRIPT, {
+      keys: [this.sessionKey(input.sid)],
+      arguments: [input.sid, input.publicId],
+    }) as Promise<SessionMetadataPatchOutcome>;
+  }
+
+  async revokeRefreshSession(
+    input: RevokeRefreshSessionInput,
+  ): Promise<RefreshSessionRevocationOutcome> {
+    return this.client.eval(REVOKE_REFRESH_SESSION_SCRIPT, {
+      keys: [this.sessionKey(input.sid)],
+      arguments: [
+        input.sid,
+        input.presentedRefreshTokenHash,
+        String(input.now),
+      ],
+    }) as Promise<RefreshSessionRevocationOutcome>;
   }
 
   async removeSession(sid: string, publicId: string): Promise<void> {
@@ -112,36 +391,6 @@ export class RedisSessionModule {
         ttlSeconds: Number(ttlResult ?? -2),
       };
     });
-  }
-
-  async updateSessions<T>(
-    publicId: string,
-    updates: Array<SessionWithTtl<T>>,
-    staleSessionIds: string[] = [],
-  ): Promise<void> {
-    if (updates.length === 0 && staleSessionIds.length === 0) {
-      return;
-    }
-
-    const pipeline = this.client.multi();
-
-    for (const update of updates) {
-      if (!update.session || update.ttlSeconds <= 0) {
-        continue;
-      }
-
-      pipeline.setEx(
-        this.sessionKey(update.sid),
-        update.ttlSeconds,
-        JSON.stringify(update.session),
-      );
-    }
-
-    for (const staleSessionId of staleSessionIds) {
-      pipeline.sRem(this.userSessionsKey(publicId), staleSessionId);
-    }
-
-    await pipeline.exec();
   }
 
   private sessionKey(sid: string): string {

--- a/backend/src/types/customAuth/auth.types.ts
+++ b/backend/src/types/customAuth/auth.types.ts
@@ -32,6 +32,7 @@ export interface AuthSessionRecord {
   publicId: UserPublicId;
   isEmailVerified: boolean;
   refreshTokenHash: RefreshTokenHash;
+  refreshVersion: number;
   previousRefreshTokenHash?: RefreshTokenHash;
   previousRefreshTokenGraceUntil?: number;
   createdAt: number;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "build": "npm run build:ts7",
     "build:ts6": "tsc6 -b && vite build",
     "build:ts7": "tsc -b && vite build",
+    "test:auth": "tsx --test tests/auth-refresh-coordinator.test.ts",
     "lint": "eslint .",
     "preview": "vite preview",
     "cypress:open": "cypress open",

--- a/frontend/src/api/authRefreshCoordinator.ts
+++ b/frontend/src/api/authRefreshCoordinator.ts
@@ -1,0 +1,32 @@
+export interface RetryableAuthRequest {
+  _retry?: boolean;
+}
+
+export function shouldAttemptAuthRefresh(
+  status: number | undefined,
+  request: RetryableAuthRequest | undefined,
+  bypassRefresh: boolean,
+): boolean {
+  return (
+    status === 401 &&
+    request !== undefined &&
+    !request._retry &&
+    !bypassRefresh
+  );
+}
+
+export class AuthRefreshCoordinator {
+  private refreshPromise: Promise<void> | null = null;
+
+  async waitForRefresh(refresh: () => Promise<void>): Promise<void> {
+    if (!this.refreshPromise) {
+      this.refreshPromise = Promise.resolve()
+        .then(refresh)
+        .finally(() => {
+          this.refreshPromise = null;
+        });
+    }
+
+    await this.refreshPromise;
+  }
+}

--- a/frontend/src/api/axiosClient.ts
+++ b/frontend/src/api/axiosClient.ts
@@ -10,6 +10,10 @@ import {
   resolveApiErrorMessage,
   type ApiErrorResponse,
 } from "./errorMessages";
+import {
+  AuthRefreshCoordinator,
+  shouldAttemptAuthRefresh,
+} from "./authRefreshCoordinator";
 
 interface RetryableRequestConfig extends InternalAxiosRequestConfig {
   _retry?: boolean;
@@ -140,7 +144,7 @@ axiosClient.interceptors.request.use((config) => {
   return config;
 });
 
-let refreshPromise: Promise<void> | null = null;
+const authRefreshCoordinator = new AuthRefreshCoordinator();
 
 const shouldBypassRefresh = (url?: string): boolean => {
   if (!url) return false;
@@ -180,11 +184,11 @@ axiosClient.interceptors.response.use(
     }
 
     const originalRequest = error.config as RetryableRequestConfig | undefined;
-    const shouldRefresh =
-      status === 401 &&
-      Boolean(originalRequest) &&
-      !originalRequest?._retry &&
-      !shouldBypassRefresh(originalRequest?.url);
+    const shouldRefresh = shouldAttemptAuthRefresh(
+      status,
+      originalRequest,
+      shouldBypassRefresh(originalRequest?.url),
+    );
 
     if (shouldRefresh && originalRequest) {
       originalRequest._retry = true;
@@ -199,16 +203,10 @@ axiosClient.interceptors.response.use(
       originalRequest._clientRequestAttempt =
         resolveClientRequestAttempt(originalRequest) + 1;
 
-      if (!refreshPromise) {
-        refreshPromise = refreshAccessSession(
-          originalRequest._clientRequestId,
-        ).finally(() => {
-          refreshPromise = null;
-        });
-      }
-
       try {
-        await refreshPromise;
+        await authRefreshCoordinator.waitForRefresh(() =>
+          refreshAccessSession(originalRequest._clientRequestId),
+        );
         return axiosClient(originalRequest);
       } catch {
         devWarn("[Axios] Session refresh failed");

--- a/frontend/tests/auth-refresh-coordinator.test.ts
+++ b/frontend/tests/auth-refresh-coordinator.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AuthRefreshCoordinator,
+  shouldAttemptAuthRefresh,
+  type RetryableAuthRequest,
+} from "../src/api/authRefreshCoordinator.ts";
+
+test("coalesces many simultaneous 401 responses into one refresh and one retry each", async () => {
+  const coordinator = new AuthRefreshCoordinator();
+  const requests: RetryableAuthRequest[] = Array.from(
+    { length: 25 },
+    () => ({}),
+  );
+  let refreshCalls = 0;
+  let retryCalls = 0;
+
+  const refresh = async (): Promise<void> => {
+    refreshCalls += 1;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  };
+
+  await Promise.all(
+    requests.map(async (request) => {
+      assert.equal(shouldAttemptAuthRefresh(401, request, false), true);
+      request._retry = true;
+      await coordinator.waitForRefresh(refresh);
+      retryCalls += 1;
+      assert.equal(shouldAttemptAuthRefresh(401, request, false), false);
+    }),
+  );
+
+  assert.equal(refreshCalls, 1);
+  assert.equal(retryCalls, requests.length);
+  assert.equal(requests.every((request) => request._retry === true), true);
+});
+
+test("shares a failed refresh and permits a later independent refresh attempt", async () => {
+  const coordinator = new AuthRefreshCoordinator();
+  const expectedError = new Error("refresh failed");
+  let refreshCalls = 0;
+  const failedRefresh = async (): Promise<void> => {
+    refreshCalls += 1;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    throw expectedError;
+  };
+
+  const results = await Promise.allSettled(
+    Array.from({ length: 10 }, () =>
+      coordinator.waitForRefresh(failedRefresh),
+    ),
+  );
+
+  assert.equal(refreshCalls, 1);
+  assert.equal(results.every((result) => result.status === "rejected"), true);
+
+  await coordinator.waitForRefresh(async () => {
+    refreshCalls += 1;
+  });
+  assert.equal(refreshCalls, 2);
+});
+
+test("resets after a successful refresh and permits a later refresh cycle", async () => {
+  const coordinator = new AuthRefreshCoordinator();
+  let refreshCalls = 0;
+  const refresh = async (): Promise<void> => {
+    refreshCalls += 1;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  };
+
+  await Promise.all([
+    coordinator.waitForRefresh(refresh),
+    coordinator.waitForRefresh(refresh),
+  ]);
+  assert.equal(refreshCalls, 1);
+
+  await coordinator.waitForRefresh(refresh);
+  assert.equal(refreshCalls, 2);
+});
+
+test("does not refresh bypass endpoints, non-401 responses, or retried requests", () => {
+  assert.equal(shouldAttemptAuthRefresh(403, {}, false), false);
+  assert.equal(shouldAttemptAuthRefresh(401, undefined, false), false);
+  assert.equal(shouldAttemptAuthRefresh(401, {}, true), false);
+  assert.equal(shouldAttemptAuthRefresh(401, { _retry: true }, false), false);
+});


### PR DESCRIPTION
-  Replaced refresh-token read/compare/write rotation with an atomic Redis operation
-  Enforced one successful rotation per session generation
-  Prevented losing concurrent requests from overwriting the accepted successor
-  Replaced stale whole-session metadata writes with atomic field-level updates
-  Made lastSeenAt monotonic
-  Made email verification a one-way false → true update
-  Preserved existing session TTL during metadata updates
-  Prevented delayed updates from recreating deleted sessions
-  Added atomic refresh-token logout and membership cleanup
-  Preserved independent sessions for separate devices/logins
-  Retained the frontend single-flight refresh coordinator and one-retry guard